### PR TITLE
[Feat][#7] 공용 UI 컴포넌트 구현 (Button, Modal, Input)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-hook-form": "^7.71.1",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^4.3.5"
+    "zod": "^4.3.5",
+    "zustand": "^5.0.10"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-dialog": "^1.1.15",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       zod:
         specifier: ^4.3.5
         version: 4.3.5
+      zustand:
+        specifier: ^5.0.10
+        version: 5.0.10(@types/react@19.2.8)(react@19.2.3)
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -2403,6 +2406,24 @@ packages:
 
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
+
+  zustand@5.0.10:
+    resolution: {integrity: sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -4847,3 +4868,8 @@ snapshots:
       zod: 4.3.5
 
   zod@4.3.5: {}
+
+  zustand@5.0.10(@types/react@19.2.8)(react@19.2.3):
+    optionalDependencies:
+      '@types/react': 19.2.8
+      react: 19.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.3))
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -449,6 +452,177 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -755,6 +929,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -946,6 +1124,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -1210,6 +1391,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -1840,6 +2025,36 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
@@ -2118,6 +2333,26 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2518,6 +2753,149 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.8)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.8)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.8
+
   '@rtsao/scc@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -2795,6 +3173,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
@@ -3009,6 +3391,8 @@ snapshots:
       object-keys: 1.1.1
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -3424,6 +3808,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -3966,6 +4352,33 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.8)(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-style-singleton: 2.2.3(@types/react@19.2.8)(react@19.2.3)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  react-remove-scroll@2.7.2(@types/react@19.2.8)(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.8)(react@19.2.3)
+      react-style-singleton: 2.2.3(@types/react@19.2.8)(react@19.2.3)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.8)(react@19.2.3)
+      use-sidecar: 1.1.3(@types/react@19.2.8)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  react-style-singleton@2.2.3(@types/react@19.2.8)(react@19.2.3):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.3
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.8
+
   react@19.2.3: {}
 
   reflect.getprototypeof@1.0.10:
@@ -4354,6 +4767,21 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@19.2.8)(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.8
+
+  use-sidecar@1.1.3(@types/react@19.2.8)(react@19.2.3):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.3
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.8
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -168,6 +168,12 @@
   --app-color-btn-pressed: var(--app-brand-orange-700);
   --app-color-btn-disabled: var(--app-brand-orange-300);
 
+  /* Sub Button (NEW) */
+  --app-color-sub-btn: var(--app-gray-700);
+  --app-color-sub-btn-hover: var(--app-gray-600);
+  --app-color-sub-btn-pressed: var(--app-gray-800);
+  --app-color-sub-btn-disabled: var(--app-gray-400);
+
   /* Background */
   --app-color-bg-1: #fafaf9;
   --app-color-bg-2: #ffffff;
@@ -177,6 +183,10 @@
   --app-color-success: #2e9d5b;
   --app-color-warning: #f4a300;
   --app-color-error: #e75402;
+
+  --app-color-success-hover: #58b17c;
+  --app-color-warning-hover: #f6b533;
+  --app-color-error-hover: #ec7635;
 
   /* Base */
   --app-color-black: #000000;
@@ -201,6 +211,12 @@
   --color-btn-pressed: var(--app-color-btn-pressed);
   --color-btn-disabled: var(--app-color-btn-disabled);
 
+  /* Sub Button */
+  --color-sub-btn: var(--app-color-sub-btn);
+  --color-sub-btn-hover: var(--app-color-sub-btn-hover);
+  --color-sub-btn-pressed: var(--app-color-sub-btn-pressed);
+  --color-sub-btn-disabled: var(--app-color-sub-btn-disabled);
+
   /* Background */
   --color-bg-1: var(--app-color-bg-1);
   --color-bg-2: var(--app-color-bg-2);
@@ -210,6 +226,8 @@
   --color-success: var(--app-color-success);
   --color-warning: var(--app-color-warning);
   --color-error: var(--app-color-error);
+
+  --color-success-hover: var(--app-color-success-hover);
 
   /* Base */
   --color-black: var(--app-color-black);

--- a/src/app/test/components/button/page.tsx
+++ b/src/app/test/components/button/page.tsx
@@ -68,7 +68,6 @@ export default function ButtonPreviewPage() {
                       variant={variant}
                       size={size}
                       rounded="full"
-                      ariaLabel={`${color} ${variant} icon button`}
                       leftIcon={<span>⚙</span>}
                     />
                   ))}

--- a/src/app/test/components/button/page.tsx
+++ b/src/app/test/components/button/page.tsx
@@ -1,0 +1,90 @@
+import { Button } from '@/components/Button';
+
+const colors = ['primary', 'secondary', 'danger', 'success', 'warning', 'contrast'] as const;
+const sizes = ['sm', 'md', 'lg', 'xl'] as const;
+const variants = ['default', 'outline', 'ghost'] as const;
+
+export default function ButtonPreviewPage() {
+  return (
+    <div className="space-y-20 bg-[#2A2A2A] p-8 text-white">
+      <h1 className="text-2xl font-bold text-white">Button Preview</h1>
+
+      <section className="space-y-16">
+        {colors.map((color) => (
+          <div key={color} className="space-y-6">
+            <h3 className="text-lg font-medium text-white">{color}</h3>
+
+            {variants.map((variant) => (
+              <div key={variant} className="flex items-center gap-4">
+                {sizes.map((size) => (
+                  <Button key={size} color={color} variant={variant} size={size}>
+                    {variant}-{size}
+                  </Button>
+                ))}
+              </div>
+            ))}
+          </div>
+        ))}
+      </section>
+
+      {/* ================= Disabled ================= */}
+      <section className="space-y-16">
+        <h2 className="text-xl font-semibold text-white">Disabled</h2>
+
+        <div className="start flex gap-12">
+          {colors.map((color) => (
+            <div key={color} className="space-y-6">
+              <h3 className="text-lg font-medium text-white">{color}</h3>
+
+              {variants.map((variant) => (
+                <div key={variant} className="flex items-center gap-4">
+                  <Button key="lg" color={color} variant={variant} size="lg" disabled>
+                    {variant}-lg
+                  </Button>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </section>
+      {/* ================= Icon Only ================= */}
+      <section className="space-y-16">
+        <h2 className="text-xl font-semibold text-white">Icon Only</h2>
+
+        {colors.map((color) => (
+          <div key={color} className="space-y-8">
+            <h3 className="text-lg font-medium text-white">{color}</h3>
+
+            {/* Default */}
+            <div className="space-y-2">
+              <div className="text-sm text-gray-400">default</div>
+
+              {variants.map((variant) => (
+                <div key={variant} className="flex items-center gap-4">
+                  {sizes.map((size) => (
+                    <Button
+                      key={size}
+                      color={color}
+                      variant={variant}
+                      size={size}
+                      rounded="full"
+                      ariaLabel={`${color} ${variant} icon button`}
+                      leftIcon={<span>⚙</span>}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center gap-6">
+              {/* 아이콘 + 라운드 사각형 */}
+              <Button leftIcon={<span>⚙</span>} />
+
+              {/* 아이콘 + 원형 */}
+              <Button leftIcon={<span>⚙</span>} rounded="full" />
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/src/app/test/components/input/page.tsx
+++ b/src/app/test/components/input/page.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/Input';
+import { Eye, EyeOff, Mail } from 'lucide-react';
+
+export default function InputTestPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [emailError, setEmailError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+
+  const validateEmail = (value: string) => {
+    if (!value) {
+      setEmailError('이메일을 입력해주세요');
+    } else if (!/\S+@\S+\.\S+/.test(value)) {
+      setEmailError('올바른 이메일 형식이 아닙니다');
+    } else {
+      setEmailError('');
+    }
+  };
+
+  const validatePassword = (value: string) => {
+    if (!value) {
+      setPasswordError('비밀번호를 입력해주세요');
+    } else if (value.length < 8) {
+      setPasswordError('비밀번호는 8자 이상이어야 합니다');
+    } else {
+      setPasswordError('');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-neutral-50 p-8">
+      <div className="mx-auto max-w-2xl">
+        <h1 className="mb-8 text-3xl font-bold text-neutral-900">Input 테스트</h1>
+
+        <div className="space-y-8 rounded-lg bg-white p-6 shadow">
+          {/* 기본 */}
+          <div>
+            <h2 className="mb-4 text-lg font-semibold">기본</h2>
+            <Input placeholder="이름을 입력하세요" />
+          </div>
+
+          {/* 라벨 */}
+          <div>
+            <h2 className="mb-4 text-lg font-semibold">라벨</h2>
+            <Input label="이름" placeholder="홍길동" />
+          </div>
+
+          {/* 필수 */}
+          <div>
+            <h2 className="mb-4 text-lg font-semibold">필수</h2>
+            <Input label="이메일" required placeholder="example@email.com" />
+          </div>
+
+          {/* 에러 */}
+          <div>
+            <h2 className="mb-4 text-lg font-semibold">에러</h2>
+            <Input
+              label="이메일"
+              required
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                validateEmail(e.target.value);
+              }}
+              error={emailError}
+              placeholder="example@email.com"
+            />
+          </div>
+
+          {/* 아이콘 */}
+          <div>
+            <h2 className="mb-4 text-lg font-semibold">아이콘</h2>
+            <Input label="이메일" icon={<Mail size={16} />} placeholder="example@email.com" />
+          </div>
+
+          {/* Disabled */}
+          <div>
+            <h2 className="mb-4 text-lg font-semibold">Disabled</h2>
+            <Input label="이름" placeholder="홍길동" disabled />
+          </div>
+
+          {/* 비밀번호 (아이콘 클릭) */}
+          <div>
+            <h2 className="mb-4 text-lg font-semibold">비밀번호 (아이콘 클릭)</h2>
+            <Input
+              label="비밀번호"
+              required
+              type={showPassword ? 'text' : 'password'}
+              value={password}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                validatePassword(e.target.value);
+              }}
+              error={passwordError}
+              placeholder="8자 이상 입력"
+              icon={showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+              onIconClick={() => setShowPassword(!showPassword)}
+            />
+          </div>
+
+          {/* 전체 조합 */}
+          <div>
+            <h2 className="mb-4 text-lg font-semibold">전체 조합</h2>
+            <div className="space-y-4">
+              <Input
+                label="이메일"
+                required
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  validateEmail(e.target.value);
+                }}
+                error={emailError}
+                icon={<Mail size={16} />}
+                placeholder="example@email.com"
+              />
+
+              <Input
+                label="비밀번호"
+                required
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => {
+                  setPassword(e.target.value);
+                  validatePassword(e.target.value);
+                }}
+                error={passwordError}
+                placeholder="8자 이상 입력"
+                icon={showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                onIconClick={() => setShowPassword(!showPassword)}
+              />
+            </div>
+          </div>
+
+          {/* 사용법 */}
+          <div className="mt-6 rounded bg-neutral-100 p-4">
+            <p className="text-sm text-neutral-600">
+              <strong>사용법:</strong>
+            </p>
+            <pre className="mt-2 text-xs">
+              {`<Input
+  label="이메일"
+  required
+  error={error}
+  icon={<Mail />}
+  placeholder="example@email.com"
+/>`}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/test/components/modal/page.tsx
+++ b/src/app/test/components/modal/page.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useModal } from '@/hooks/useModal';
+import { Modal } from '@/components/Modal';
+import { Button } from '@/components/Button';
+
+export default function ModalTestPage() {
+  const basicModal = useModal();
+  const confirmModal = useModal();
+  const formModal = useModal();
+
+  return (
+    <div className="min-h-screen bg-neutral-50 p-8">
+      <div className="mx-auto max-w-4xl">
+        <h1 className="mb-8 text-3xl font-bold text-neutral-900">Modal 테스트</h1>
+
+        <div className="space-y-4 rounded-lg bg-white p-6 shadow">
+          <div>
+            <h2 className="mb-2 text-lg font-semibold">기본 모달</h2>
+            <Button onClick={basicModal.open}>열기</Button>
+          </div>
+
+          <div>
+            <h2 className="mb-2 text-lg font-semibold">확인 모달 (가로 반반)</h2>
+            <Button onClick={confirmModal.open}>열기</Button>
+          </div>
+
+          <div>
+            <h2 className="mb-2 text-lg font-semibold">폼 모달 (세로 버튼)</h2>
+            <Button onClick={formModal.open}>열기</Button>
+          </div>
+
+          <div className="mt-6 rounded bg-neutral-100 p-4">
+            <p className="text-sm text-neutral-600">
+              <strong>사용법:</strong>
+            </p>
+            <pre className="mt-2 text-xs">
+              {`const modal = useModal();
+
+<Modal.Root {...modal.props}>
+  <Modal.Header title="제목" subTitle="설명" />
+  <Modal.Body>내용</Modal.Body>
+  <Modal.Footer>버튼</Modal.Footer>
+</Modal.Root>`}
+            </pre>
+          </div>
+        </div>
+      </div>
+
+      {/* 기본 모달 */}
+      <Modal.Root {...basicModal.props} a11yTitle="기본 모달">
+        <Modal.Header title="기본 모달" subTitle="간단한 안내 메시지" />
+        <Modal.Body>
+          <p className="text-sm text-neutral-600">이것은 기본 모달입니다.</p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={basicModal.close}>닫기</Button>
+        </Modal.Footer>
+      </Modal.Root>
+
+      {/* 확인 모달 */}
+      <Modal.Root {...confirmModal.props} a11yTitle="확인 모달">
+        <Modal.Header title="정말 삭제하시겠습니까?" subTitle="이 작업은 되돌릴 수 없습니다" />
+        <Modal.Body>
+          <p className="text-sm text-neutral-600">삭제하면 모든 데이터가 영구적으로 제거됩니다.</p>
+        </Modal.Body>
+        <Modal.Footer full>
+          <Button variant="ghost" onClick={confirmModal.close}>
+            취소
+          </Button>
+          <Button variant="default" onClick={confirmModal.close}>
+            삭제
+          </Button>
+        </Modal.Footer>
+      </Modal.Root>
+
+      {/* 폼 모달 */}
+      <Modal.Root {...formModal.props} a11yTitle="폼 모달">
+        <Modal.Header title="프로필 수정" subTitle="정보를 입력해주세요" />
+        <Modal.Body>
+          <div className="space-y-4">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-neutral-700">이름</label>
+              <input
+                type="text"
+                className="w-full rounded border border-neutral-300 px-3 py-2 text-sm"
+                placeholder="홍길동"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-neutral-700">이메일</label>
+              <input
+                type="email"
+                className="w-full rounded border border-neutral-300 px-3 py-2 text-sm"
+                placeholder="example@email.com"
+              />
+            </div>
+          </div>
+        </Modal.Body>
+        <Modal.Footer direction="col" full>
+          <Button onClick={formModal.close}>저장</Button>
+          <Button variant="ghost" onClick={formModal.close}>
+            취소
+          </Button>
+        </Modal.Footer>
+      </Modal.Root>
+    </div>
+  );
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -21,7 +21,6 @@ type ButtonSize = 'sm' | 'md' | 'lg' | 'xl';
 
 /**
  * Button의 모서리 라운드 형태
- * - md: 살짝 둥근 사각형
  * - lg: 기본 버튼
  * - full: 원형 / pill
  */
@@ -30,31 +29,17 @@ type ButtonRounded = 'lg' | 'full';
 /**
  * Button 컴포넌트 Props
  *
- * + as: 'button' | 'a' 에 따라 렌더링될 HTML 태그
- * + href: as="a" 일 때 이동할 링크
- * + variant: 버튼의 시각적 스타일 유형
- * + color: 버튼의 색상
- * + size: 버튼의 크기
- * + rounded: 버튼의 모서리 라운드 형태
- * + disabled: 버튼의 비활성화 여부
- * + leftIcon / rightIcon: 버튼 좌우에 아이콘을 추가
- * + children: 버튼 텍스트
- * + ariaLabel: 아이콘만 있는 버튼에서 스크린 리더 접근성 제공
- * + className: 추가적인 CSS 클래스
+ * + variant / color / size / rounded: 버튼 스타일 제어
+ * + leftIcon / rightIcon / children: 버튼 콘텐츠
+ * + onClick, disabled, aria-* 등 기본 button 속성은 그대로 전달됨
  */
-interface ButtonProps {
-  as?: 'button' | 'a';
-  href?: string;
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: ButtonVariant;
   color?: ButtonColor;
   size?: ButtonSize;
   rounded?: ButtonRounded;
-  disabled?: boolean;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
-  children?: React.ReactNode;
-  ariaLabel?: string;
-  className?: string;
 }
 
 /* Style maps */
@@ -133,7 +118,7 @@ const colorStyles: Record<ButtonColor, Record<ButtonVariant, string>> = {
 const baseStyles =
   'inline-flex items-center justify-center font-medium ' +
   'transition-colors ' +
-  'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary' +
+  'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary ' +
   'disabled:pointer-events-none disabled:opacity-50';
 
 /* Component */
@@ -142,34 +127,26 @@ const baseStyles =
 /**
  * 공용 Button 컴포넌트
  * - 다양한 시각적 스타일 옵션 제공
- * - as="button" / as="a" 모두 지원
+ * - action 전용 button 컴포넌트
  * - 텍스트 버튼 / 아이콘 버튼 모두 지원
- * - 아이콘 전용 버튼에서 aria-label 필수
+ * - 아이콘 전용 버튼에서 aria-label 사용 권장
  */
 export function Button({
-  as = 'button',
-  href,
   variant = 'default',
   color = 'primary',
   size = 'md',
   rounded = 'lg',
-  disabled = false,
   leftIcon,
   rightIcon,
   children,
-  ariaLabel,
   className,
+  ...props
 }: ButtonProps) {
-  const Component = as;
-
   const isIconOnly = !children && (leftIcon || rightIcon);
 
   return (
-    <Component
-      href={as === 'a' ? href : undefined}
-      disabled={as === 'button' ? disabled : undefined}
-      aria-disabled={disabled}
-      aria-label={ariaLabel}
+    <button
+      {...props}
       className={clsx(
         baseStyles,
         isIconOnly ? iconSizeStyles[size] : sizeStyles[size],
@@ -181,6 +158,6 @@ export function Button({
       {leftIcon && <span aria-hidden>{leftIcon}</span>}
       {children && <span>{children}</span>}
       {rightIcon && <span aria-hidden>{rightIcon}</span>}
-    </Component>
+    </button>
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,186 @@
+import clsx from 'clsx';
+import React from 'react';
+
+/**
+ * Button의 시각적 스타일 유형
+ * - default: 기본 채움 버튼
+ * - outline: 외곽선 버튼
+ * - ghost: 배경 없는 버튼
+ */
+type ButtonVariant = 'default' | 'outline' | 'ghost';
+
+/**
+ * Button의 색상
+ */
+type ButtonColor = 'primary' | 'secondary' | 'danger' | 'success' | 'warning' | 'contrast';
+
+/**
+ * Button의 높이 / 패딩 / 타이포 스케일
+ */
+type ButtonSize = 'sm' | 'md' | 'lg' | 'xl';
+
+/**
+ * Button의 모서리 라운드 형태
+ * - md: 살짝 둥근 사각형
+ * - lg: 기본 버튼
+ * - full: 원형 / pill
+ */
+type ButtonRounded = 'lg' | 'full';
+
+/**
+ * Button 컴포넌트 Props
+ *
+ * + as: 'button' | 'a' 에 따라 렌더링될 HTML 태그
+ * + href: as="a" 일 때 이동할 링크
+ * + variant: 버튼의 시각적 스타일 유형
+ * + color: 버튼의 색상
+ * + size: 버튼의 크기
+ * + rounded: 버튼의 모서리 라운드 형태
+ * + disabled: 버튼의 비활성화 여부
+ * + leftIcon / rightIcon: 버튼 좌우에 아이콘을 추가
+ * + children: 버튼 텍스트
+ * + ariaLabel: 아이콘만 있는 버튼에서 스크린 리더 접근성 제공
+ * + className: 추가적인 CSS 클래스
+ */
+interface ButtonProps {
+  as?: 'button' | 'a';
+  href?: string;
+  variant?: ButtonVariant;
+  color?: ButtonColor;
+  size?: ButtonSize;
+  rounded?: ButtonRounded;
+  disabled?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  children?: React.ReactNode;
+  ariaLabel?: string;
+  className?: string;
+}
+
+/* Style maps */
+/* Style maps */
+
+/**
+ * 텍스트 버튼용 사이즈 스타일
+ * - height / padding / gap / font-size 포함
+ */
+const sizeStyles: Record<ButtonSize, string> = {
+  sm: 'h-6 px-2 gap-1 text-btn-3',
+  md: 'h-8 px-3 gap-1.5 text-btn-2',
+  lg: 'h-10 px-4 gap-2 text-btn-2',
+  xl: 'h-12 px-6 gap-2 text-btn-1',
+};
+
+/**
+ * 아이콘 전용 버튼 사이즈
+ * - padding 없음
+ * - width === height
+ */
+const iconSizeStyles: Record<ButtonSize, string> = {
+  sm: 'h-6 w-6',
+  md: 'h-8 w-8',
+  lg: 'h-10 w-10',
+  xl: 'h-12 w-12',
+};
+
+/**
+ * 버튼 모서리 라운드 스타일
+ */
+const roundedStyles: Record<ButtonRounded, string> = {
+  lg: 'rounded-lg',
+  full: 'rounded-full',
+};
+
+/**
+ * 색상 + variant 조합 스타일
+ */
+const colorStyles: Record<ButtonColor, Record<ButtonVariant, string>> = {
+  primary: {
+    default: 'bg-primary text-white hover:bg-btn-hover',
+    outline: 'bg-primary/10 border border-primary-dark text-primary hover:text-btn-hover',
+    ghost: 'text-primary hover:text-primary-400',
+  },
+  secondary: {
+    default: 'bg-bg-1 text-gray-700 hover:bg-bg-2',
+    outline: 'border border-gray-200 text-gray-200',
+    ghost: 'text-gray-200',
+  },
+  danger: {
+    default: 'bg-error text-white hover:bg-error-hover',
+    outline: 'border border-error bg-error/10 text-error hover:text-error-hover',
+    ghost: 'text-error hover:text-error-hover',
+  },
+  success: {
+    default: 'bg-success text-white hover:bg-success-hover',
+    outline: 'border border-success bg-success/10 text-success hover:text-success-hover',
+    ghost: 'text-success hover:bg-success-50',
+  },
+  warning: {
+    default: 'bg-warning text-white hover:bg-warning-hover',
+    outline: 'border border-warning bg-warning/10 text-warning hover:text-warning-hover',
+    ghost: 'text-warning hover:text-warning-hover',
+  },
+  contrast: {
+    default: 'bg-sub-btn text-white hover:bg-sub-btn-hover',
+    outline: 'border border-sub-btn bg-sub-btn/10 text-sub-btn hover:text-sub-btn-hover',
+    ghost: 'text-sub-btn hover:text-sub-btn-hover',
+  },
+};
+
+/**
+ * 모든 버튼에 공통으로 적용되는 기본 스타일
+ */
+const baseStyles =
+  'inline-flex items-center justify-center font-medium ' +
+  'transition-colors ' +
+  'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary' +
+  'disabled:pointer-events-none disabled:opacity-50';
+
+/* Component */
+/* Component */
+
+/**
+ * 공용 Button 컴포넌트
+ * - 다양한 시각적 스타일 옵션 제공
+ * - as="button" / as="a" 모두 지원
+ * - 텍스트 버튼 / 아이콘 버튼 모두 지원
+ * - 아이콘 전용 버튼에서 aria-label 필수
+ */
+export function Button({
+  as = 'button',
+  href,
+  variant = 'default',
+  color = 'primary',
+  size = 'md',
+  rounded = 'lg',
+  disabled = false,
+  leftIcon,
+  rightIcon,
+  children,
+  ariaLabel,
+  className,
+}: ButtonProps) {
+  const Component = as;
+
+  const isIconOnly = !children && (leftIcon || rightIcon);
+
+  return (
+    <Component
+      href={as === 'a' ? href : undefined}
+      disabled={as === 'button' ? disabled : undefined}
+      aria-disabled={disabled}
+      aria-label={ariaLabel}
+      className={clsx(
+        baseStyles,
+        isIconOnly ? iconSizeStyles[size] : sizeStyles[size],
+        roundedStyles[rounded],
+        colorStyles[color][variant],
+        className,
+      )}
+    >
+      {leftIcon && <span aria-hidden>{leftIcon}</span>}
+      {children && <span>{children}</span>}
+      {rightIcon && <span aria-hidden>{rightIcon}</span>}
+    </Component>
+  );
+}

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { Input as ShadcnInput } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+/**
+ * Input 컴포넌트의 Props
+ *
+ * @property label - 라벨 텍스트
+ * @property required - 필수 입력 여부
+ * @property error - 에러 메시지 (하단에 빨간색으로 표시)
+ * @property icon - 인풋 우측에 표시할 아이콘
+ * @property onIconClick - 아이콘 클릭 핸들러 (제공시 아이콘이 클릭 가능해짐)
+ * @property placeholder - placeholder 텍스트
+ * @property disabled - 비활성화 여부
+ */
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  required?: boolean;
+  error?: string;
+  icon?: React.ReactNode;
+  onIconClick?: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+const INPUT_BASE_STYLES =
+  'typo-body-8 placeholder:typo-placeholder border-gray-200 placeholder:text-gray-400 focus:border-gray-400 shadow-none focus-visible:ring-0';
+const INPUT_ERROR_STYLES = 'border-error focus:border-error';
+const INPUT_DISABLED_STYLES = 'cursor-not-allowed bg-gray-300 text-gray-400 border-gray-300';
+
+/**
+ * Input 컴포넌트
+ *
+ * shadcn Input을 기반으로 라벨, 필수 표시, 에러 메시지, 아이콘을 추가한 컴포넌트
+ */
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  (
+    { label, required, error, icon, onIconClick, placeholder, disabled, className, ...props },
+    ref,
+  ) => {
+    return (
+      <div className="space-y-2">
+        {/* 라벨 + 필수 표시 */}
+        {label && (
+          <label className="typo-label mb-2 block text-gray-700">
+            {label}
+            {required && <span className="text-primary ml-2">필수</span>}
+          </label>
+        )}
+
+        {/* 인풋 + 아이콘 */}
+        <div className="relative">
+          <ShadcnInput
+            ref={ref}
+            placeholder={placeholder}
+            disabled={disabled}
+            className={cn(
+              INPUT_BASE_STYLES,
+              icon && 'pr-10',
+              error && INPUT_ERROR_STYLES,
+              disabled && INPUT_DISABLED_STYLES,
+              className,
+            )}
+            {...props}
+          />
+          {icon &&
+            (onIconClick ? (
+              <button
+                type="button"
+                onClick={onIconClick}
+                className="absolute top-1/2 right-3 -translate-y-1/2 text-neutral-500 hover:text-neutral-700"
+              >
+                {icon}
+              </button>
+            ) : (
+              <div className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-neutral-500">
+                {icon}
+              </div>
+            ))}
+        </div>
+
+        {/* 에러 메시지 */}
+        {error && <p className="typo-caption text-error">{error}</p>}
+      </div>
+    );
+  },
+);
+
+Input.displayName = 'Input';

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import * as React from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+/**
+ * Modal (Compound Component)
+ *
+ * - shadcn/ui(Radix Dialog) 기반 모달 래퍼
+ * - Root에서 컨테이너 스타일/레이아웃을 통일하고
+ * - Header/Body/Footer를 조합해서 사용
+ *
+ */
+
+/**
+ * Modal.Root props
+ *
+ * @property open - 모달 열림 여부
+ * @property onOpenChange - open 상태 변경 핸들러(overlay/esc 닫기 포함)
+ * @property a11yTitle - 스크린리더용 제목(Radix Dialog 접근성 요구사항)
+ * @property className - DialogContent(컨테이너) 추가 클래스
+ * @property children - Modal.Header/Body/Footer 조합
+ */
+type ModalRootProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  className?: string;
+  a11yTitle?: string;
+  children: React.ReactNode;
+};
+
+function Root({ open, onOpenChange, className, a11yTitle = '모달', children }: ModalRootProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={cn(
+          // 컨테이너 기본 스타일 (카드 외형/여백/레이아웃)
+          'flex min-h-50 w-[320px] flex-col gap-6 rounded-xl border border-neutral-100 bg-white px-7 py-6 shadow-2xl',
+          className,
+        )}
+      >
+        {/* Radix DialogContent는 DialogTitle(스크린리더용 포함)을 요구 */}
+        <DialogTitle className="sr-only">{a11yTitle}</DialogTitle>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Modal.Header props
+ *
+ * @property title - 모달 제목(필수)
+ * @property subTitle - 서브타이틀/설명(필수)
+ * @property className - 헤더 영역 추가 클래스
+ */
+type ModalHeaderProps = {
+  title: string;
+  subTitle: string;
+  className?: string;
+};
+
+function Header({ title, subTitle, className }: ModalHeaderProps) {
+  return (
+    <DialogHeader className={className}>
+      <h2 className="typo-heading-2 mb-1 text-neutral-900">{title}</h2>
+      <p className="typo-body-7 text-neutral-400">{subTitle}</p>
+    </DialogHeader>
+  );
+}
+
+/**
+ * Modal.Body props
+ *
+ * - 컨텐츠 영역 (텍스트/폼/리스트 등 자유롭게 구성)
+ *
+ * @property children - 바디 컨텐츠
+ * @property className - 바디 영역 추가 클래스(스크롤 필요 시 여기서 설정)
+ *
+ */
+type ModalBodyProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+function Body({ children, className }: ModalBodyProps) {
+  return <div className={className}>{children}</div>;
+}
+
+/**
+ * Modal.Footer props
+ *
+ * - 버튼 영역 레이아웃을 최소 옵션으로 제어
+ *
+ * @property direction - 버튼 배치 방향 (row: 가로, col: 세로)
+ * @property full - 버튼 폭 채우기
+ *   - row + full: 자식에 flex-1 적용 (2개면 1/2 + 1/2)
+ *   - col + full: 자식에 w-full 적용 (세로 full 버튼)
+ * @property className - 푸터 영역 추가 클래스
+ *
+ */
+type ModalFooterProps = {
+  direction?: 'row' | 'col';
+  full?: boolean;
+  children: React.ReactNode;
+  className?: string;
+};
+
+function Footer({ direction = 'row', full = false, children, className }: ModalFooterProps) {
+  const directionClass = direction === 'col' ? 'flex-col' : 'flex-row';
+  const fullClass = full ? (direction === 'col' ? '[&>*]:w-full' : '[&>*]:flex-1') : '';
+
+  return (
+    <div className={cn('flex justify-end gap-2 p-0', directionClass, fullClass, className)}>
+      {children}
+    </div>
+  );
+}
+
+export const Modal = {
+  Root,
+  Header,
+  Body,
+  Footer,
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80',
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    {...props}
+  />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg leading-none font-semibold tracking-tight', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-muted-foreground text-sm', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
+        'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg',
         className,
       )}
       {...props}

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+/**
+ * 모달 제어를 위한 Hook
+ *
+ * 로컬 상태 기반으로 간단하게 모달을 제어합니다.
+ *
+ */
+export function useModal() {
+  const [open, setOpen] = useState(false);
+
+  return {
+    /**
+     * 모달 열기
+     */
+    open: () => setOpen(true),
+
+    /**
+     * 모달 닫기
+     */
+    close: () => setOpen(false),
+
+    /**
+     * 현재 열림 상태
+     */
+    isOpen: open,
+
+    /**
+     * Modal.Root에 spread할 수 있는 props
+     */
+    props: {
+      open,
+      onOpenChange: setOpen,
+    },
+  };
+}


### PR DESCRIPTION

## 작업 내용

### 1. Button 컴포넌트

- variant (default / outline / ghost)
- color (primary / secondary / danger / success / warning / contrast)
- size (sm / md / lg / xl)
- 아이콘 버튼 지원 (leftIcon / rightIcon)
- HTML button 속성 확장
- 추후 링크 버튼 필요시 따로 추가 예정

### 2. Modal 컴포넌트

- Compound component 패턴 적용 (Modal.Header, Modal.Body, Modal.Footer)
- `useModal` 훅 제공 (useState 기반)
- shadcn Dialog 기반
- 추후 전역 상태 필요시 리팩토링 예정


### 3. Input 컴포넌트

- shadcn Input 래퍼
- label, 필수 표시, 에러 메시지 지원
- 아이콘 슬롯 및 클릭 핸들러 지원
- disabled 스타일

### 4. 기타

- CSS 토큰 추가
- 컴포넌트 테스트 페이지 생성 (`/test/components`)
- zustand, shadcn dialog 설치

## 이슈 번호
close #7 

## 스크린샷 
추가 예정

| Button | Modal | Input |
| --- | --- | --- |
| (스크린샷) | (스크린샷) | (스크린샷) |
