### PR TITLE
[Chore] 개발용 DB 관리 스크립트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "prepare": "husky"
+    "prepare": "husky",
+    "db:start": "node scripts/db.mjs start",
+    "db:status": "node scripts/db.mjs status",
+    "db:stop": "node scripts/db.mjs stop"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
+    "axios": "^1.13.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",
-    "db:start": "node scripts/db.mjs start",
-    "db:status": "node scripts/db.mjs status",
-    "db:stop": "node scripts/db.mjs stop"
+    "db:start": "node --env-file=.env.local scripts/db.mjs start",
+    "db:status": "node --env-file=.env.local scripts/db.mjs status",
+    "db:stop": "node --env-file=.env.local scripts/db.mjs stop"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      axios:
+        specifier: ^1.13.4
+        version: 1.13.4
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -979,6 +982,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -986,6 +992,9 @@ packages:
   axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
+
+  axios@1.13.4:
+    resolution: {integrity: sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1064,6 +1073,10 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
@@ -1123,6 +1136,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1365,9 +1382,22 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1781,6 +1811,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
@@ -2006,6 +2044,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3271,11 +3312,21 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.11.1: {}
+
+  axios@1.13.4:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axobject-query@4.1.0: {}
 
@@ -3355,6 +3406,10 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@14.0.2: {}
 
   concat-map@0.0.1: {}
@@ -3410,6 +3465,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -3794,9 +3851,19 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.15.11: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   function-bind@1.1.2: {}
 
@@ -4195,6 +4262,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   mimic-function@5.0.1: {}
 
   minimatch@3.1.2:
@@ -4357,6 +4430,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/scripts/db.mjs
+++ b/scripts/db.mjs
@@ -1,0 +1,53 @@
+const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080';
+
+const command = process.argv[2];
+
+async function startDb() {
+  console.log('🚀 DB 시작 요청 중...');
+  const res = await fetch(`${BASE_URL}/api/v1/dev/db/start`, { method: 'POST' });
+  if (res.ok) {
+    console.log('✅ DB 시작 요청 완료! 3~6분 후 사용 가능');
+  } else {
+    console.error('❌ DB 시작 실패:', res.status);
+  }
+}
+
+async function getStatus() {
+  console.log('🔍 DB 상태 확인 중...');
+  const res = await fetch(`${BASE_URL}/api/v1/dev/db/status`);
+  const data = await res.json();
+  if (data.status === 'available') {
+    console.log('✅ DB 사용 가능!');
+  } else {
+    console.log('⏳ DB 아직 준비 중...');
+  }
+}
+
+async function stopDb() {
+  console.log('🛑 DB 중지 요청 중...');
+  const res = await fetch(`${BASE_URL}/api/v1/dev/db/stop`, { method: 'POST' });
+  if (res.ok) {
+    console.log('✅ DB 중지 요청 완료!');
+  } else {
+    console.error('❌ DB 중지 실패:', res.status);
+  }
+}
+
+switch (command) {
+  case 'start':
+    startDb();
+    break;
+  case 'status':
+    getStatus();
+    break;
+  case 'stop':
+    stopDb();
+    break;
+  default:
+    console.log(`
+사용법:
+  npm run db:start   - DB 시작 (3~6분 소요)
+  npm run db:status  - DB 상태 확인
+  npm run db:stop    - DB 중지
+    `);
+}

--- a/scripts/db.mjs
+++ b/scripts/db.mjs
@@ -46,8 +46,8 @@ switch (command) {
   default:
     console.log(`
 사용법:
-  npm run db:start   - DB 시작 (3~6분 소요)
-  npm run db:status  - DB 상태 확인
-  npm run db:stop    - DB 중지
+  pnpm db:start   - DB 시작 (3~6분 소요)
+  pnpm db:status  - DB 상태 확인
+  pnpm db:stop    - DB 중지
     `);
 }

--- a/src/app/api/axiosInstance.ts
+++ b/src/app/api/axiosInstance.ts
@@ -1,0 +1,33 @@
+import axios, { AxiosError } from 'axios';
+
+export type ApiError = {
+  code?: string;
+  message?: string;
+};
+
+export const axiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_BACKEND_URL,
+  timeout: 10_000,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+/**
+ * 공통 에러 처리:
+ * - 백엔드가 내려주는 { code, message } 형태면 그대로 throw
+ * - 응답이 없으면(네트워크/타임아웃) 표준 에러로 throw
+ */
+axiosInstance.interceptors.response.use(
+  (res) => res,
+  (error: AxiosError<ApiError>) => {
+    const data = error.response?.data;
+
+    if (data) {
+      return Promise.reject(data);
+    }
+
+    return Promise.reject({
+      code: 'NETWORK_ERROR',
+      message: '네트워크 오류가 발생했습니다.',
+    } satisfies ApiError);
+  },
+);

--- a/src/app/api/dev/db.ts
+++ b/src/app/api/dev/db.ts
@@ -1,0 +1,35 @@
+import { axiosInstance } from '../axiosInstance';
+
+export type DbStatus = 'available' | 'unavailable';
+
+export type DbStatusResponse = {
+  status: DbStatus;
+};
+
+/**
+ * DB 시작
+ * - 개발 시작할 때 호출
+ * - 3~6분 소요
+ */
+export async function startDb(): Promise<void> {
+  await axiosInstance.post('/api/v1/dev/db/start');
+}
+
+/**
+ * DB 상태 확인
+ * - available: 사용 가능 (모든 백엔드 API 사용 가능)
+ * - unavailable: 사용 불가
+ */
+export async function getDbStatus(): Promise<DbStatus> {
+  const { data } = await axiosInstance.get<DbStatusResponse>('/api/v1/dev/db/status');
+  return data.status;
+}
+
+/**
+ * DB 중지
+ * - 개발 작업 마무리할 때 호출
+ * - 8~15분 소요
+ */
+export async function stopDb(): Promise<void> {
+  await axiosInstance.post('/api/v1/dev/db/stop');
+}


### PR DESCRIPTION
## 작업 내용

개발 환경에서 DB를 관리하기 위한 CLI 스크립트 추가

### 사용법

```bash
# 개발 시작할 때 (3~6분 소요)
pnpm db:start

# DB 상태 확인 (available / unavailable)
pnpm db:status

# 개발 종료할 때
pnpm db:stop
```

### 추가된 파일
- scripts/db.mjs - CLI 스크립트
- src/app/api/dev/db.ts - API 함수 (코드에서 사용 가능)
- package.json - npm scripts 추가
- src/app/api/axiosInstance.ts - Axios 인스턴스 (공통 에러 처리 포함)

### 구현 방식
- Node.js 스크립트는 Next.js와 달리 `.env.local`을 자동으로 로드하지 않음.
- Node.js 20.6+에서 지원하는 `--env-file` 플래그를 사용하여 환경변수 로드.
- `"db:start": "node --env-file=.env.local scripts/db.mjs start"`
<img width="1030" height="332" alt="image" src="https://github.com/user-attachments/assets/7a4e9175-20db-4047-b5ca-181c5309bb29" />


### 참고사항
- db:start 호출 후 3~6분 대기 필요
- db:status가 available 반환 시 모든 백엔드 API 사용 가능
- Node.js 20.6 이상 필요 (--env-file 플래그 지원)
- Axios 인스턴스는 추후 auth 등 다른 API에서도 재사용 예정

