### PR TITLE
 [Feat][#15] 토큰 자동 갱신 및 로그아웃 기능 구현

### DIFF
--- a/src/app/api/auth/login.ts
+++ b/src/app/api/auth/login.ts
@@ -29,3 +29,28 @@ export async function loginEmail(payload: LoginPayload): Promise<LoginResponse> 
   const res = await axiosInstance.post<LoginResponse>('/api/v1/users/login/email', payload);
   return res.data;
 }
+
+// 리프레시 토큰 요청 페이로드
+export type RefreshPayload = {
+  idToken: string;
+  refreshToken: string;
+};
+
+// 리프레시 토큰 응답
+export type RefreshResponse = {
+  access_token: string;
+  id_token: string;
+  expires_in: number;
+  token_type: string;
+};
+
+// 토큰 갱신 API
+export async function refreshTokens(payload: RefreshPayload): Promise<RefreshResponse> {
+  const res = await axiosInstance.post<RefreshResponse>('/api/v1/users/token/refresh', payload);
+  return res.data;
+}
+
+// 로그아웃 API
+export async function logoutApi(): Promise<void> {
+  await axiosInstance.post('/api/v1/users/logout');
+}

--- a/src/app/api/axiosInstance.ts
+++ b/src/app/api/axiosInstance.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { authCookies } from '@/utils/auth';
 
 export type ApiError = {
@@ -12,6 +12,21 @@ export const axiosInstance = axios.create({
   headers: { 'Content-Type': 'application/json' },
 });
 
+// 토큰 갱신 중복 방지 플래그
+let isRefreshing = false;
+let refreshSubscribers: ((token: string) => void)[] = [];
+
+// 대기 중인 요청들에게 새 토큰 전달
+const onRefreshed = (token: string) => {
+  refreshSubscribers.forEach((callback) => callback(token));
+  refreshSubscribers = [];
+};
+
+// 토큰 갱신 대기열에 추가
+const addRefreshSubscriber = (callback: (token: string) => void) => {
+  refreshSubscribers.push(callback);
+};
+
 // 요청 인터셉터: 토큰 자동 첨부
 axiosInstance.interceptors.request.use((config) => {
   const token = authCookies.getAccessToken();
@@ -23,10 +38,74 @@ axiosInstance.interceptors.request.use((config) => {
   return config;
 });
 
-// 응답 인터셉터: 공통 에러 처리
+// 응답 인터셉터: 401 에러 시 토큰 갱신 + 공통 에러 처리
 axiosInstance.interceptors.response.use(
   (res) => res,
-  (error: AxiosError<ApiError>) => {
+  async (error: AxiosError<ApiError>) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+
+    // 401 에러이고, 재시도하지 않은 요청인 경우
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      // 토큰 갱신 API 자체에서 401이 발생한 경우 → 로그인 페이지로
+      if (originalRequest.url?.includes('/token/refresh')) {
+        authCookies.clearTokens();
+        if (typeof window !== 'undefined') {
+          window.location.href = '/auth/login';
+        }
+        return Promise.reject(error);
+      }
+
+      // 이미 갱신 중이면 대기
+      if (isRefreshing) {
+        return new Promise((resolve) => {
+          addRefreshSubscriber((token: string) => {
+            originalRequest.headers.Authorization = `Bearer ${token}`;
+            resolve(axiosInstance(originalRequest));
+          });
+        });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        const idToken = authCookies.getIdToken();
+        const refreshToken = authCookies.getRefreshToken();
+
+        if (!idToken || !refreshToken) {
+          throw new Error('No tokens');
+        }
+
+        // 토큰 갱신 API 호출
+        const res = await axiosInstance.post('/api/v1/users/token/refresh', {
+          idToken,
+          refreshToken,
+        });
+
+        const { access_token, id_token } = res.data;
+
+        // 새 토큰 저장
+        authCookies.updateTokens(access_token, id_token);
+
+        // 대기 중인 요청들에게 새 토큰 전달
+        onRefreshed(access_token);
+
+        // 원래 요청 재시도
+        originalRequest.headers.Authorization = `Bearer ${access_token}`;
+        return axiosInstance(originalRequest);
+      } catch {
+        // 갱신 실패 → 로그아웃 처리
+        authCookies.clearTokens();
+        if (typeof window !== 'undefined') {
+          window.location.href = '/auth/login';
+        }
+        return Promise.reject(error);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    // 그 외 에러 처리
     const data = error.response?.data;
 
     if (data) {

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,4 +1,9 @@
+'use client';
+
 import Link from 'next/link';
+import { useAuthStore } from '@/stores/authStore';
+import { Button } from '@/components/Button';
+import { logoutApi } from '@/app/api/auth/login';
 
 const items = [
   {
@@ -16,6 +21,18 @@ const items = [
 ];
 
 export default function TestHubPage() {
+  const { isLoggedIn, logout } = useAuthStore();
+
+  const handleLogout = async () => {
+    try {
+      await logoutApi(); // 서버에 로그아웃 요청
+    } catch {
+      // API 실패해도 로컬 로그아웃은 진행
+    }
+    logout(); // 쿠키 삭제 + 상태 초기화
+    alert('로그아웃 되었습니다');
+  };
+
   return (
     <main className="from-bg-1 bg-linear-to-b to-white">
       <div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-10 px-6 py-12">
@@ -29,6 +46,25 @@ export default function TestHubPage() {
           <p className="mt-3 max-w-3xl text-base text-gray-600">
             스타일/토큰/컴포넌트가 정상 동작하는지 빠르게 확인하는 라우팅 허브입니다.
           </p>
+
+          {/* 로그인 상태 표시 */}
+          <div className="mt-4 flex items-center gap-4">
+            <span className="text-sm text-gray-600">
+              로그인 상태: {isLoggedIn ? '✅ 로그인됨' : '❌ 로그아웃'}
+            </span>
+            {isLoggedIn && (
+              <Button variant="outline" size="sm" onClick={handleLogout}>
+                로그아웃
+              </Button>
+            )}
+            {!isLoggedIn && (
+              <Link href="/auth/login">
+                <Button variant="outline" size="sm">
+                  로그인
+                </Button>
+              </Link>
+            )}
+          </div>
 
           <div className="mt-6 flex flex-wrap gap-3">
             <Link

--- a/src/hooks/useGoogle.ts
+++ b/src/hooks/useGoogle.ts
@@ -2,11 +2,12 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useAuthStore } from '@/stores/authStore';
 import { getGoogleToken } from '@/app/api/auth/google';
-import { authCookies } from '@/utils/auth';
 
 export function useGoogleAuth() {
+  const logout = useAuthStore((state) => state.logout);
+
   // (1) 구글 로그인 함수
-  const loginWithGoogle = async () => {
+  const loginWithGoogle = () => {
     const params = new URLSearchParams({
       client_id: process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID!,
       response_type: 'code',
@@ -20,8 +21,8 @@ export function useGoogleAuth() {
 
   // (2) 구글 로그아웃 함수
   const logoutWithGoogle = () => {
-    // 1. 토큰 삭제
-    authCookies.clearTokens();
+    // 1. 토큰 삭제 + Zustand 상태 초기화
+    logout();
 
     // 2. Cognito 세션 로그아웃
     const params = new URLSearchParams({
@@ -50,10 +51,10 @@ export function useGoogleLoginSideEffect() {
       try {
         // 1. 구글 로그인 코드로 토큰 교환
         setGoogleLoading(true);
-        const { access_token, refresh_token } = await getGoogleToken(code);
+        const { access_token, refresh_token, id_token } = await getGoogleToken(code);
 
         // 2. 토큰 저장
-        login(access_token, refresh_token);
+        login(access_token, refresh_token, id_token);
         setGoogleLoading(false);
 
         // 3. 메인 페이지로 이동

--- a/src/hooks/useLoginForm.ts
+++ b/src/hooks/useLoginForm.ts
@@ -27,10 +27,10 @@ export function useLoginForm() {
   const submit = async (values: LoginFormValues) => {
     try {
       // 1. 로그인 API 호출 (백엔드는 snake_case 사용)
-      const { access_token, refresh_token } = await loginEmail(values);
+      const { access_token, refresh_token, id_token } = await loginEmail(values);
 
       // 2. 쿠키 저장 + Zustand 상태 업데이트
-      login(access_token, refresh_token);
+      login(access_token, refresh_token, id_token);
 
       // 3. 메인 페이지로 이동
       router.push('/my-space');

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -5,7 +5,7 @@ interface AuthState {
   isLoggedIn: boolean;
 
   // 액션
-  login: (accessToken: string, refreshToken: string) => void;
+  login: (accessToken: string, refreshToken: string, idToken: string) => void;
   logout: () => void;
   checkAuth: () => void; // 페이지 새로고침 시 쿠키에서 상태 복원
 }
@@ -13,8 +13,8 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set) => ({
   isLoggedIn: false,
 
-  login: (accessToken, refreshToken) => {
-    authCookies.setTokens(accessToken, refreshToken);
+  login: (accessToken, refreshToken, idToken) => {
+    authCookies.setTokens(accessToken, refreshToken, idToken);
     set({ isLoggedIn: true });
   },
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -2,6 +2,7 @@ import Cookies from 'js-cookie';
 
 const ACCESS_TOKEN_KEY = 'accessToken';
 const REFRESH_TOKEN_KEY = 'refreshToken';
+const ID_TOKEN_KEY = 'idToken';
 
 const COOKIE_OPTIONS = {
   secure: process.env.NODE_ENV === 'production',
@@ -11,14 +12,30 @@ const COOKIE_OPTIONS = {
 
 export const authCookies = {
   // 토큰 저장
-  setTokens: (accessToken: string, refreshToken: string) => {
+  setTokens: (accessToken: string, refreshToken: string, idToken: string) => {
     Cookies.set(ACCESS_TOKEN_KEY, accessToken, {
       ...COOKIE_OPTIONS,
       expires: 1 / 24, // 1시간
     });
     Cookies.set(REFRESH_TOKEN_KEY, refreshToken, {
       ...COOKIE_OPTIONS,
-      expires: 7, // 7일
+      expires: 3, // 3일
+    });
+    Cookies.set(ID_TOKEN_KEY, idToken, {
+      ...COOKIE_OPTIONS,
+      expires: 1 / 24, // 1시간 (access token과 동일)
+    });
+  },
+
+  // 토큰 갱신 (리프레시 시 - refresh_token 제외)
+  updateTokens: (accessToken: string, idToken: string) => {
+    Cookies.set(ACCESS_TOKEN_KEY, accessToken, {
+      ...COOKIE_OPTIONS,
+      expires: 1 / 24,
+    });
+    Cookies.set(ID_TOKEN_KEY, idToken, {
+      ...COOKIE_OPTIONS,
+      expires: 1 / 24,
     });
   },
 
@@ -28,10 +45,14 @@ export const authCookies = {
   // Refresh Token 읽기
   getRefreshToken: () => Cookies.get(REFRESH_TOKEN_KEY),
 
+  // ID Token 읽기
+  getIdToken: () => Cookies.get(ID_TOKEN_KEY),
+
   // 토큰 삭제 (로그아웃)
   clearTokens: () => {
     Cookies.remove(ACCESS_TOKEN_KEY, { path: '/' });
     Cookies.remove(REFRESH_TOKEN_KEY, { path: '/' });
+    Cookies.remove(ID_TOKEN_KEY, { path: '/' });
   },
 
   // 로그인 여부


### PR DESCRIPTION
## 작업 내용

### 1. 토큰 자동 갱신 (Refresh)
- `axiosInstance` 응답 인터셉터에 401 에러 처리 로직 추가
- 액세스 토큰 만료 시 `refreshToken`과 `idToken`으로 자동 갱신
- 동시 다발 요청 시 중복 갱신 방지 (큐 패턴 적용)
  - `isRefreshing` 플래그로 갱신 중복 방지
  - `refreshSubscribers` 배열로 대기 중인 요청 관리
- 갱신 실패 시 자동 로그아웃 및 로그인 페이지 리다이렉트 
> 추후 리다이렉트 모달로 수정

### 2. ID Token 관리 추가
- `authCookies`에 `idToken` 저장/조회/삭제 기능 추가
- `setTokens()`: accessToken, refreshToken, idToken 저장
- `updateTokens()`: 갱신 시 accessToken, idToken만 업데이트
- `getIdToken()`: idToken 조회

### 3. 로그아웃 기능 개선
- `logoutApi()` 추가: 서버에 로그아웃 요청
- `useGoogleAuth.logoutWithGoogle()`: `authCookies.clearTokens()` → `authStore.logout()` 변경
  - 쿠키 삭제 + Zustand 상태 초기화 동시 처리

### 4. 구글 로그인 id_token 처리
- `getGoogleToken()` 응답에서 `id_token` 추출
- `login()` 함수에 `idToken` 파라미터 추가

### 5. 토큰 갱신 테스트 UI
- `/test` 페이지에 토큰 갱신 테스트 버튼 추가
- 액세스 토큰 만료 시뮬레이션 기능
- `users/me` API 호출 테스트

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `src/app/api/axiosInstance.ts` | 401 에러 시 토큰 자동 갱신 로직 |
| `src/app/api/auth/login.ts` | `refreshTokens()`, `logoutApi()` 추가 |
| `src/utils/auth.ts` | `idToken` 관리 함수 추가, `updateTokens()` 추가 |
| `src/stores/authStore.ts` | `login()` 시그니처에 `idToken` 추가 |
| `src/hooks/useGoogle.ts` | `id_token` 처리, `logout()` 호출 방식 변경 |
| `src/app/test/page.tsx` | 토큰 갱신 테스트 UI |

## 이슈 번호
close #15 

## 스크린샷 (선택)

1. 로그아웃
   - logout() 호출하여 쿠키 비워지는 거 확인 완료
 2. 토큰 갱신
   - access 토큰 invalid 처리 후
   - api 요청 시 토큰 갱신되는 거 확인 완료

