### PR TITLE
[Refactor][#24]: Tailwind @theme gray 토큰 등록 및 전체 치환

### DIFF
--- a/src/app/auth/components/LoginForm.tsx
+++ b/src/app/auth/components/LoginForm.tsx
@@ -71,15 +71,15 @@ export function LoginForm() {
 
       {/* 하단 링크 */}
       <div className="flex items-center justify-center gap-4">
-        <Link href="/" className="typo-btn-2 text-(--app-gray-500) hover:underline">
+        <Link href="/" className="typo-btn-2 text-gray-500 hover:underline">
           아이디 찾기
         </Link>
-        <span className="h-3.5 w-px bg-(--app-gray-200)" />
-        <Link href="/" className="typo-btn-2 text-(--app-gray-500) hover:underline">
+        <span className="h-3.5 w-px bg-gray-200" />
+        <Link href="/" className="typo-btn-2 text-gray-500 hover:underline">
           비밀번호 찾기
         </Link>
-        <span className="h-3.5 w-px bg-(--app-gray-200)" />
-        <Link href="/auth/signup" className="typo-btn-2 text-(--app-gray-500) hover:underline">
+        <span className="h-3.5 w-px bg-gray-200" />
+        <Link href="/auth/signup" className="typo-btn-2 text-gray-500 hover:underline">
           회원가입
         </Link>
       </div>

--- a/src/app/auth/components/SignupForm.tsx
+++ b/src/app/auth/components/SignupForm.tsx
@@ -173,7 +173,7 @@ export function SignupForm() {
               checked={isAllChecked}
               onCheckedChange={(checked) => handleAgreeAll(checked === true)}
             />
-            <span className="typo-heading-3 text-(--app-gray-800)">전체동의</span>
+            <span className="typo-heading-3 text-gray-800">전체동의</span>
           </label>
 
           {AGREEMENT_ITEMS.map((item) => (
@@ -186,13 +186,13 @@ export function SignupForm() {
                   onCheckedChange={(checked) => form.setValue(item.id, checked === true)}
                 />
                 {item.required && <span className="typo-label text-primary">필수</span>}
-                <span className="typo-body-7 text-(--app-gray-800)">{item.label}</span>
+                <span className="typo-body-7 text-gray-800">{item.label}</span>
               </label>
 
               {item.showLink && (
                 <button
                   type="button"
-                  className="typo-label text-(--app-gray-400) underline hover:text-(--app-gray-500)"
+                  className="typo-label text-gray-400 underline hover:text-gray-500"
                   onClick={() => {
                     // TODO: 약관 보기 모달/페이지 연결
                   }}

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -12,7 +12,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
   return (
     <div className="relative flex h-screen overflow-hidden">
       {/* 좌측: 메인 콘텐츠 영역 (스크롤 가능) */}
-      <main className="no-scrollbar h-screen w-120 overflow-y-auto bg-(--app-gray-100) px-12 py-7.5">
+      <main className="no-scrollbar h-screen w-120 overflow-y-auto bg-gray-100 px-12 py-7.5">
         <header className="mb-12 flex items-center gap-2">
           <AuthLogo />
         </header>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -12,9 +12,7 @@ export default function LoginPage() {
           <br />
           For you <span className="text-primary">AnsimON</span>
         </h1>
-        <p className="typo-body-4 text-(--app-gray-400)">
-          No personal credit checks or founder guarantee.
-        </p>
+        <p className="typo-body-4 text-gray-400">No personal credit checks or founder guarantee.</p>
       </div>
 
       {/* 폼 — useSearchParams 사용으로 Suspense 필요 */}

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -9,7 +9,7 @@ export default function SignupPage() {
       {/* 제목 */}
       <div className="mb-8">
         <h1 className="typo-display-2 mb-2 text-black">회원가입</h1>
-        <p className="typo-body-4 text-(--app-gray-500)">새로운 계정을 만들어보세요</p>
+        <p className="typo-body-4 text-gray-500">새로운 계정을 만들어보세요</p>
       </div>
 
       {/* 폼 */}

--- a/src/app/auth/verify/page.tsx
+++ b/src/app/auth/verify/page.tsx
@@ -32,13 +32,11 @@ export default function VerifyPage() {
     <div className="pb-24">
       <div className="mb-8">
         <h1 className="typo-display-2 mb-2 text-black">이메일 인증</h1>
-        <p className="typo-body-4 text-(--app-gray-500)">
-          인증번호를 입력하고 인증을 완료해주세요.
-        </p>
+        <p className="typo-body-4 text-gray-500">인증번호를 입력하고 인증을 완료해주세요.</p>
       </div>
 
       {isLoading ? (
-        <div className="flex flex-col items-center gap-4 pt-4 text-(--app-gray-400)">
+        <div className="flex flex-col items-center gap-4 pt-4 text-gray-400">
           <Loader2 size={40} className="animate-spin" />
           <span className="typo-body-7">이메일 정보를 확인하고 있어요...</span>
         </div>

--- a/src/app/my-space/case/components/CaseHeader.tsx
+++ b/src/app/my-space/case/components/CaseHeader.tsx
@@ -78,7 +78,7 @@ export function CaseHeader({
   };
 
   return (
-    <div className="flex w-full justify-between border-b border-(--app-gray-100) p-6">
+    <div className="flex w-full justify-between border-b border-gray-100 p-6">
       <div className="flex flex-col gap-1">
         {/* 제목 표시 / 편집 */}
         {isEditing ? (
@@ -98,10 +98,10 @@ export function CaseHeader({
             className="flex items-center gap-2"
           >
             <h1 className="typo-heading-2">{title || '사건 제목'}</h1>
-            <EditOutlineIcon className="aria-hidden size-5 text-(--app-gray-400)" />
+            <EditOutlineIcon className="aria-hidden size-5 text-gray-400" />
           </button>
         )}
-        <span className="typo-body-8 text-(--app-gray-400)">최종 수정일: {updatedAt}</span>
+        <span className="typo-body-8 text-gray-400">최종 수정일: {updatedAt}</span>
       </div>
       <div className="flex items-center gap-2">
         <Button color="secondary" size="lg" onClick={onSave} loading={isSaving}>

--- a/src/app/my-space/case/components/CaseProgress.tsx
+++ b/src/app/my-space/case/components/CaseProgress.tsx
@@ -31,7 +31,7 @@ export function CaseProgress({ currentStep }: CaseProgressProps) {
                 className="h-px flex-1"
                 style={{
                   backgroundImage:
-                    'repeating-linear-gradient(to right, var(--app-gray-200) 0, var(--app-gray-200) 4px, transparent 4px, transparent 8px)',
+                    'repeating-linear-gradient(to right, var(--color-gray-200) 0, var(--color-gray-200) 4px, transparent 4px, transparent 8px)',
                 }}
               />
             )}
@@ -39,12 +39,12 @@ export function CaseProgress({ currentStep }: CaseProgressProps) {
             {/* 스텝 아이템 */}
             <div className="flex w-30 flex-col items-center">
               <span
-                className={`typo-heading-6 transition-colors duration-300 ${isActive ? 'text-primary' : 'text-(--app-gray-200)'}`}
+                className={`typo-heading-6 transition-colors duration-300 ${isActive ? 'text-primary' : 'text-gray-200'}`}
               >
                 STEP 0{item.step}
               </span>
               <span
-                className={`typo-heading-2 transition-colors duration-300 ${isActive ? 'text-(--app-gray-800)' : 'text-(--app-gray-300)'}`}
+                className={`typo-heading-2 transition-colors duration-300 ${isActive ? 'text-gray-800' : 'text-gray-300'}`}
               >
                 {item.label}
               </span>

--- a/src/app/my-space/case/components/StepCollect.tsx
+++ b/src/app/my-space/case/components/StepCollect.tsx
@@ -1,7 +1,7 @@
 export function StepCollect() {
   return (
     <div className="flex items-center justify-center p-20">
-      <h2 className="typo-heading-2 text-(--app-gray-400)">증거 업로드</h2>
+      <h2 className="typo-heading-2 text-gray-400">증거 업로드</h2>
     </div>
   );
 }

--- a/src/app/my-space/case/components/StepComplete.tsx
+++ b/src/app/my-space/case/components/StepComplete.tsx
@@ -1,7 +1,7 @@
 export function StepComplete() {
   return (
     <div className="flex items-center justify-center p-20">
-      <h2 className="typo-heading-2 text-(--app-gray-400)">마무리</h2>
+      <h2 className="typo-heading-2 text-gray-400">마무리</h2>
     </div>
   );
 }

--- a/src/app/my-space/case/components/StepDocument.tsx
+++ b/src/app/my-space/case/components/StepDocument.tsx
@@ -1,7 +1,7 @@
 export function StepDocument() {
   return (
     <div className="flex items-center justify-center p-20">
-      <h2 className="typo-heading-2 text-(--app-gray-400)">고소장 작성</h2>
+      <h2 className="typo-heading-2 text-gray-400">고소장 작성</h2>
     </div>
   );
 }

--- a/src/app/my-space/case/components/StepTimeline.tsx
+++ b/src/app/my-space/case/components/StepTimeline.tsx
@@ -1,7 +1,7 @@
 export function StepTimeline() {
   return (
     <div className="flex items-center justify-center p-20">
-      <h2 className="typo-heading-2 text-(--app-gray-400)">타임라인 정리</h2>
+      <h2 className="typo-heading-2 text-gray-400">타임라인 정리</h2>
     </div>
   );
 }

--- a/src/app/my-space/layout.tsx
+++ b/src/app/my-space/layout.tsx
@@ -7,9 +7,7 @@ export default function MySpaceLayout({ children }: { children: ReactNode }) {
     <SidebarProvider>
       <div className="bg-bg1 flex min-h-screen w-full pt-4 pl-6">
         <MySpaceSidebar />
-        <main className="bg-bg-2 flex-1 rounded-tl-3xl border border-(--app-gray-100)">
-          {children}
-        </main>
+        <main className="bg-bg-2 flex-1 rounded-tl-3xl border border-gray-100">{children}</main>
       </div>
     </SidebarProvider>
   );

--- a/src/app/styles/base.css
+++ b/src/app/styles/base.css
@@ -18,7 +18,7 @@
 
     background-color: var(--color-bg-1);
 
-    color: var(--app-gray-900);
+    color: var(--color-gray-900);
   }
 
   h1,
@@ -29,11 +29,11 @@
   h6 {
     font-weight: 600;
 
-    color: var(--app-gray-900);
+    color: var(--color-gray-900);
   }
 
   p {
-    color: var(--app-gray-600);
+    color: var(--color-gray-600);
   }
 
   :focus-visible {

--- a/src/app/styles/index.css
+++ b/src/app/styles/index.css
@@ -37,7 +37,7 @@
 }
 
 .rdp-weekday {
-  color: var(--app-gray-500);
+  color: var(--color-gray-500);
   font-size: 0.875rem;
 }
 
@@ -49,11 +49,11 @@
 }
 
 .rdp-day_button:hover {
-  background-color: var(--app-gray-300);
+  background-color: var(--color-gray-300);
 }
 
 .rdp-selected .rdp-day_button {
-  background-color: var(--app-gray-500);
+  background-color: var(--color-gray-500);
 }
 
 /* shadcn/ui 변수 어댑터 */

--- a/src/app/styles/tokens.css
+++ b/src/app/styles/tokens.css
@@ -217,6 +217,19 @@
   --color-sub-btn-pressed: var(--app-color-sub-btn-pressed);
   --color-sub-btn-disabled: var(--app-color-sub-btn-disabled);
 
+  /* Gray */
+  --color-gray-50: var(--app-gray-50);
+  --color-gray-100: var(--app-gray-100);
+  --color-gray-200: var(--app-gray-200);
+  --color-gray-300: var(--app-gray-300);
+  --color-gray-400: var(--app-gray-400);
+  --color-gray-500: var(--app-gray-500);
+  --color-gray-600: var(--app-gray-600);
+  --color-gray-700: var(--app-gray-700);
+  --color-gray-800: var(--app-gray-800);
+  --color-gray-900: var(--app-gray-900);
+  --color-gray-950: var(--app-gray-950);
+
   /* Background */
   --color-bg-1: var(--app-color-bg-1);
   --color-bg-2: var(--app-color-bg-2);

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -31,10 +31,9 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
 }
 
 const INPUT_BASE_STYLES =
-  'w-full rounded-md border px-3 py-1 transition-colors focus-visible:outline-none typo-body-7 placeholder:typo-placeholder border-(--app-gray-200) placeholder:text-(--app-gray-400) focus:border-(--app-gray-400) bg-white text-(--app-gray-900)';
+  'w-full rounded-md border px-3 py-1 transition-colors focus-visible:outline-none typo-body-7 placeholder:typo-placeholder border-gray-200 placeholder:text-gray-400 focus:border-gray-400 bg-white text-gray-900';
 const INPUT_ERROR_STYLES = 'border-error border-[1.5px] focus:border-error';
-const INPUT_DISABLED_STYLES =
-  'cursor-not-allowed bg-(--app-gray-300) text-(--app-gray-500) border-(--app-gray-300)';
+const INPUT_DISABLED_STYLES = 'cursor-not-allowed bg-gray-300 text-gray-500 border-gray-300';
 const INPUT_SIZE_STYLES: Record<InputSize, string> = {
   sm: 'h-8', // 32px
   md: 'h-10', // 40px
@@ -75,7 +74,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <div>
         {/* 라벨 + 필수 표시 */}
         {label && (
-          <label className="typo-label mb-2 block text-(--app-gray-700)">
+          <label className="typo-label mb-2 block text-gray-700">
             {label}
             {required && !hideRequiredLabel && <span className="text-primary ml-2">필수</span>}
           </label>

--- a/src/components/MySpaceSidebar.tsx
+++ b/src/components/MySpaceSidebar.tsx
@@ -67,7 +67,7 @@ export function MySpaceSidebar() {
         <div className="overflow-hidden opacity-100 transition-opacity delay-150 duration-300 group-data-[collapsible=icon]:w-0 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-0">
           <GnbLogo />
         </div>
-        <SidebarTrigger className="h-4 w-4 text-(--app-gray-400)" />
+        <SidebarTrigger className="h-4 w-4 text-gray-400" />
       </SidebarHeader>
 
       <SidebarContent className="justify-center p-0">
@@ -83,7 +83,7 @@ export function MySpaceSidebar() {
                       asChild
                       isActive={isActive}
                       tooltip={item.label}
-                      className="typo-heading-5 h-12 p-0 text-(--app-gray-300) group-data-[collapsible=icon]:size-12! data-[active=true]:font-semibold data-[active=true]:text-(--app-gray-800)"
+                      className="typo-heading-5 h-12 p-0 text-gray-300 group-data-[collapsible=icon]:size-12! data-[active=true]:font-semibold data-[active=true]:text-gray-800"
                     >
                       <Link href={item.href}>
                         <span className="relative size-12 shrink-0">
@@ -116,7 +116,7 @@ export function MySpaceSidebar() {
       <SidebarFooter className="gap-3 p-0">
         <SidebarMenu className="max-h-40 gap-3 overflow-hidden opacity-100 transition-[opacity,max-height] delay-150 duration-300 group-data-[collapsible=icon]:max-h-0 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-0">
           <SidebarMenuItem className="h-auto">
-            <SidebarMenuButton asChild className="typo-heading-6 h-auto p-0 text-(--app-gray-400)">
+            <SidebarMenuButton asChild className="typo-heading-6 h-auto p-0 text-gray-400">
               <Link href="/support" className="flex items-center gap-2">
                 <SidebarIcon1 className="size-4 shrink-0" />
                 고객 센터
@@ -125,7 +125,7 @@ export function MySpaceSidebar() {
           </SidebarMenuItem>
           {/* TODO: 도움말 센터 페이지 시안 확정 후 링크 연결 */}
           <SidebarMenuItem>
-            <SidebarMenuButton className="typo-heading-6 h-auto p-0 text-(--app-gray-400)">
+            <SidebarMenuButton className="typo-heading-6 h-auto p-0 text-gray-400">
               <SidebarIcon2 className="size-4 shrink-0" />
               <span className="inline-flex items-center gap-0.5">
                 도움말 센터
@@ -135,7 +135,7 @@ export function MySpaceSidebar() {
           </SidebarMenuItem>
           {/* TODO: 이용약관 및 정책 페이지 시안 확정 후 링크 연결 */}
           <SidebarMenuItem>
-            <SidebarMenuButton className="typo-heading-6 h-auto p-0 text-(--app-gray-400)">
+            <SidebarMenuButton className="typo-heading-6 h-auto p-0 text-gray-400">
               <SidebarIcon3 className="size-4 shrink-0" />
               <span className="inline-flex items-center gap-0.5">
                 이용약관 및 정책
@@ -157,7 +157,7 @@ export function MySpaceSidebar() {
             >
               <div className="flex items-center gap-2 px-1 py-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:px-0">
                 <ProfileIcon className="size-5 shrink-0" />
-                <span className="typo-body-3 text-(--app-gray-600) transition-opacity delay-150 duration-300 group-data-[collapsible=icon]:w-0 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-0">
+                <span className="typo-body-3 text-gray-600 transition-opacity delay-150 duration-300 group-data-[collapsible=icon]:w-0 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-0">
                   {isLoggedIn ? `${user?.name ?? '...'}님` : 'Guest'}
                 </span>
               </div>

--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -94,7 +94,7 @@ export default function Slider() {
             onClick={() => instanceRef.current?.moveToIdx(idx)}
             aria-label={`${idx + 1}번 슬라이드로 이동`}
             className={`h-3 w-3 rounded-full transition ${
-              currentSlide === idx ? 'bg-primary' : 'bg-(--app-gray-200)'
+              currentSlide === idx ? 'bg-primary' : 'bg-gray-200'
             }`}
           />
         ))}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -507,7 +507,7 @@ const sidebarMenuButtonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'hover:text-(--app-gray-600) hover:font-semibold transition-colors',
+        default: 'hover:text-gray-600 hover:font-semibold transition-colors',
         outline:
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -20,7 +20,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 origin-[--radix-tooltip-content-transform-origin] overflow-hidden rounded-md bg-(--app-gray-100) px-3 py-1.5 text-xs',
+        'animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 origin-[--radix-tooltip-content-transform-origin] overflow-hidden rounded-md bg-gray-100 px-3 py-1.5 text-xs',
         className,
       )}
       {...props}


### PR DESCRIPTION
## 작업 내용

### 배경
기존에 gray 컬러를 `@theme`에 등록하지 않아 `text-(--app-gray-400)` 같은 arbitrary value 문법을 사용해야 했음.
`@theme`에 gray 토큰을 등록하여 `text-gray-400` 같은 Tailwind 네이티브 유틸리티 사용이 가능하도록 개선.

### 변경 사항

1. **`tokens.css` `@theme` 블록에 gray 50~950 토큰 등록**
   - `--color-gray-50` ~ `--color-gray-950` 11개 추가

2. **TSX 파일 Tailwind 클래스 치환 (17개 파일)**
   - `text-(--app-gray-*)` → `text-gray-*`
   - `bg-(--app-gray-*)` → `bg-gray-*`
   - `border-(--app-gray-*)` → `border-gray-*`
   - `hover:`, `focus:`, `placeholder:` 등 변형 포함

3. **CSS 파일 변수 참조 통일 (2개 파일)**
   - `base.css`, `index.css`: `var(--app-gray-*)` → `var(--color-gray-*)`

4. **인라인 스타일 변수 참조 통일 (1개 파일)**
   - `CaseProgress.tsx`: `var(--app-gray-200)` → `var(--color-gray-200)`

### 효과
- 가독성 향상: `text-(--app-gray-400)` → `text-gray-400`
- IDE 자동완성 지원
- 일관된 토큰 참조 체계 (`@theme` 브릿지 패턴 통일)

## 이슈 번호
close #24 

## 스크린샷 (선택)
변경 없음 (시각적 차이 없는 리팩토링)
