### PR TITLE
[Refactor][#26]: API 에러 타입 통합 및 에러 처리 개선

### DIFF
--- a/src/app/api/auth/login.ts
+++ b/src/app/api/auth/login.ts
@@ -15,15 +15,6 @@ export type LoginResponse = {
   refresh_token: string;
 };
 
-// 로그인 실패 응답
-// USER_NOT_CONFIRMED: 이메일 인증 미완료
-// INVALID_CREDENTIALS: 이메일 또는 비밀번호 오류
-// USER_NOT_FOUND: 사용자 없음
-export type LoginErrorResponse = {
-  code?: string;
-  message?: string;
-};
-
 // 이메일 로그인 API
 export async function loginEmail(payload: LoginPayload): Promise<LoginResponse> {
   const res = await axiosInstance.post<LoginResponse>('/api/v1/users/login/email', payload);

--- a/src/app/api/auth/signup.ts
+++ b/src/app/api/auth/signup.ts
@@ -12,11 +12,6 @@ export type VerifyEmailPayload = {
   code: string;
 };
 
-export type SignupErrorResponse = {
-  code?: string;
-  message?: string;
-};
-
 export async function signupEmail(payload: SignupEmailPayload): Promise<void> {
   await axiosInstance.post('/api/v1/users/signup/email', payload);
 }

--- a/src/app/api/axiosInstance.ts
+++ b/src/app/api/axiosInstance.ts
@@ -1,10 +1,6 @@
 import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { authCookies } from '@/utils/auth';
-
-export type ApiError = {
-  code?: string;
-  message?: string;
-};
+import type { ApiError } from '@/types/api';
 
 export const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BACKEND_URL,

--- a/src/app/auth/components/EmailVerifyForm.tsx
+++ b/src/app/auth/components/EmailVerifyForm.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import { useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { VerifyEmailFormValues, verifyEmailSchema } from '@/schemas/auth/verify-email.schema';
-import { useRouter } from 'next/navigation';
-import { SignupErrorResponse, verifyEmail, resendVerificationEmail } from '@/app/api/auth/signup';
+import { useEmailVerifyForm } from '@/hooks/useEmailVerifyForm';
 import { ActionInput } from '@/components/ActionInput';
 
 type EmailVerifyFormProps = {
@@ -14,57 +9,7 @@ type EmailVerifyFormProps = {
 
 /** 이메일 인증 폼 컴포넌트 */
 export function EmailVerifyForm({ email }: EmailVerifyFormProps) {
-  const router = useRouter();
-  const [isResending, setIsResending] = useState(false);
-  const [isVerifying, setIsVerifying] = useState(false);
-
-  const form = useForm<VerifyEmailFormValues>({
-    resolver: zodResolver(verifyEmailSchema),
-    mode: 'onBlur',
-    defaultValues: {
-      email,
-      code: '',
-    },
-  });
-
-  const handleResend = async () => {
-    setIsResending(true);
-    try {
-      await resendVerificationEmail(email);
-      // TODO: 성공 토스트 메시지
-    } catch (err) {
-      console.error('이메일 재전송 실패:', err);
-      // TODO: 실패 토스트 메시지
-    } finally {
-      setIsResending(false);
-    }
-  };
-
-  const handleVerify = async () => {
-    const isValid = await form.trigger('code');
-    if (!isValid) return;
-
-    setIsVerifying(true);
-    try {
-      const values = form.getValues();
-      await verifyEmail(values);
-
-      sessionStorage.removeItem('signupEmail');
-      router.replace('/auth/login');
-    } catch (err) {
-      const data = err as SignupErrorResponse;
-
-      if (data.code === 'INVALID_CODE') {
-        form.setError('code', { message: '인증 번호가 올바르지 않습니다.' });
-      } else if (data.code === 'EXPIRED_CODE') {
-        form.setError('code', { message: '인증 번호가 만료되었습니다. 재전송 요청을 해주세요.' });
-      } else {
-        console.error('이메일 인증 실패:', data);
-      }
-    } finally {
-      setIsVerifying(false);
-    }
-  };
+  const { form, handleResend, handleVerify, isResending, isVerifying } = useEmailVerifyForm(email);
 
   return (
     <div className="flex flex-col gap-2">

--- a/src/hooks/useEmailVerifyForm.ts
+++ b/src/hooks/useEmailVerifyForm.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { VerifyEmailFormValues, verifyEmailSchema } from '@/schemas/auth/verify-email.schema';
+import { verifyEmail, resendVerificationEmail } from '@/app/api/auth/signup';
+import type { ApiError } from '@/types/api';
+
+export function useEmailVerifyForm(email: string) {
+  const router = useRouter();
+  const [isResending, setIsResending] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+
+  // React Hook Form 설정
+  const form = useForm<VerifyEmailFormValues>({
+    resolver: zodResolver(verifyEmailSchema),
+    mode: 'onBlur',
+    defaultValues: {
+      email,
+      code: '',
+    },
+  });
+
+  // 인증번호 재전송 핸들러
+  const handleResend = async () => {
+    setIsResending(true);
+    try {
+      await resendVerificationEmail(email);
+      // TODO: 성공 토스트 메시지
+    } catch (err) {
+      console.error('이메일 재전송 실패:', err);
+      // TODO: 실패 토스트 메시지
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  // 인증번호 확인 핸들러
+  const handleVerify = async () => {
+    const isValid = await form.trigger('code');
+    if (!isValid) return;
+
+    setIsVerifying(true);
+    try {
+      const values = form.getValues();
+      await verifyEmail(values);
+
+      sessionStorage.removeItem('signupEmail');
+      router.replace('/auth/login');
+    } catch (err) {
+      const data = err as ApiError;
+
+      if (data.code === 'EXPIRED_CODE') {
+        form.setError('code', { message: data.message });
+      } else {
+        form.setError('code', { message: data?.message ?? '인증에 실패했습니다' });
+      }
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  return {
+    form,
+    handleResend,
+    handleVerify,
+    isResending,
+    isVerifying,
+  };
+}

--- a/src/hooks/useLoginForm.ts
+++ b/src/hooks/useLoginForm.ts
@@ -5,7 +5,8 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { loginSchema, type LoginFormValues } from '@/schemas/auth/login.schema';
-import { loginEmail, LoginErrorResponse } from '@/app/api/auth/login';
+import { loginEmail } from '@/app/api/auth/login';
+import type { ApiError } from '@/types/api';
 import { useAuthStore } from '@/stores/authStore';
 
 export function useLoginForm() {
@@ -37,22 +38,18 @@ export function useLoginForm() {
       const redirect = searchParams.get('redirect') || '/my-space/case/collect';
       router.replace(redirect);
     } catch (err) {
-      const data = err as LoginErrorResponse;
+      const data = err as ApiError;
 
-      // 에러 코드에 따른 처리
       if (data?.code === 'USER_NOT_FOUND') {
-        form.setError('email', { message: '존재하지 않는 이메일입니다' });
+        form.setError('email', { message: data.message });
       } else if (data?.code === 'INVALID_CREDENTIALS') {
-        // 이메일 인증 페이지에서 사용할 수 있도록 세션에 저장
         sessionStorage.setItem('loginEmail', values.email);
-        form.setError('password', { message: '이메일 또는 비밀번호가 올바르지 않습니다' });
+        form.setError('password', { message: data.message });
       } else if (data?.code === 'USER_NOT_CONFIRMED') {
-        // TODO: 이메일 인증 페이지로 리다이렉트 모달 추가
         sessionStorage.setItem('loginEmail', values.email);
-        form.setError('root', { message: '이메일 인증이 완료되지 않았습니다' });
+        form.setError('root', { message: data.message });
       } else {
-        // 기타 에러
-        form.setError('root', { message: data?.message || '로그인에 실패했습니다' });
+        form.setError('root', { message: data?.message ?? '로그인에 실패했습니다' });
       }
     }
   };

--- a/src/hooks/useSignupForm.ts
+++ b/src/hooks/useSignupForm.ts
@@ -5,7 +5,8 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { signupSchema, type SignupFormValues } from '@/schemas/auth/signup.schema';
-import { signupEmail, SignupEmailPayload, SignupErrorResponse } from '@/app/api/auth/signup';
+import { signupEmail, SignupEmailPayload } from '@/app/api/auth/signup';
+import type { ApiError } from '@/types/api';
 
 export function useSignupForm() {
   const router = useRouter();
@@ -41,12 +42,14 @@ export function useSignupForm() {
       sessionStorage.setItem('signupEmail', values.email);
       router.push('/auth/verify');
     } catch (err) {
-      const data = err as SignupErrorResponse;
+      const data = err as ApiError;
 
       if (data?.code === 'EMAIL_ALREADY_EXISTS') {
-        form.setError('email', { message: '이미 가입된 이메일입니다' });
+        form.setError('email', { message: data.message });
+      } else if (data?.code === 'INVALID_PASSWORD') {
+        form.setError('password', { message: data.message });
       } else {
-        console.error('회원가입 실패:', data);
+        form.setError('root', { message: data?.message ?? '회원가입에 실패했습니다' });
       }
 
       sessionStorage.removeItem('signupEmail');

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,22 @@
+/** 백엔드 에러 코드 */
+export type ApiErrorCode =
+  // Auth - Signup
+  | 'EMAIL_ALREADY_EXISTS'
+  | 'INVALID_PASSWORD'
+  // Auth - Verify
+  | 'INVALID_CODE'
+  | 'EXPIRED_CODE'
+  // Auth - Login
+  | 'USER_NOT_FOUND'
+  | 'INVALID_CREDENTIALS'
+  | 'USER_NOT_CONFIRMED'
+  // Auth - Token
+  | 'INVALID_REFRESH_TOKEN'
+  // Frontend
+  | 'NETWORK_ERROR';
+
+/** 백엔드 공통 에러 응답 */
+export type ApiError = {
+  code: ApiErrorCode;
+  message?: string;
+};


### PR DESCRIPTION
## 작업 내용

### 1. API 에러 타입 통합

기존에 에러 타입이 3곳에 중복 정의되어 있었음:
- `axiosInstance.ts` → `ApiError` (code?: string, message?: string)
- `login.ts` → `LoginErrorResponse` (code?: string, message?: string)
- `signup.ts` → `SignupErrorResponse` (code?: string, message?: string)

이를 `src/types/api.ts` 하나로 통합:
- `ApiErrorCode`: 백엔드 OpenAPI 스펙 기준 유니온 타입 (`EMAIL_ALREADY_EXISTS`, `INVALID_PASSWORD`, `INVALID_CODE`, `EXPIRED_CODE`, `USER_NOT_FOUND`, `INVALID_CREDENTIALS`, `USER_NOT_CONFIRMED`, `INVALID_REFRESH_TOKEN`, `NETWORK_ERROR`)
- `ApiError`: `{ code: ApiErrorCode; message?: string }` - 기존 `code?: string`에서 유니온 타입으로 강화

### 2. 에러 메시지 하드코딩 제거

백엔드가 모든 에러 응답에 `message`를 제공하고 있어서, 프론트에서 하드코딩하던 메시지를 제거하고 `data.message`를 직접 사용하도록 변경:

**useLoginForm.ts**
- before: `form.setError('email', { message: '존재하지 않는 이메일입니다' })`
- after: `form.setError('email', { message: data.message })`
- `USER_NOT_FOUND`, `INVALID_CREDENTIALS`, `USER_NOT_CONFIRMED` 3개 분기 모두 동일하게 변경
- 예상치 못한 에러의 else 분기만 fallback 메시지 유지

**useSignupForm.ts**
- before: `form.setError('email', { message: data.message ?? '이미 가입된 이메일입니다' })`
- after: `form.setError('email', { message: data.message })`

**useEmailVerifyForm.ts**
- before: `form.setError('code', { message: '인증 번호가 만료되었습니다. 재전송 요청을 해주세요.' })`
- after: `form.setError('code', { message: data.message })`

### 3. 누락된 에러 분기 추가

**useSignupForm.ts**
- 백엔드 스펙에 `INVALID_PASSWORD` (비밀번호 정책 위반, 400) 에러가 있었으나 프론트에서 처리하지 않고 있었음
- `INVALID_PASSWORD` 분기 추가 → `password` 필드에 에러 메시지 표시

### 4. EmailVerifyForm 훅 분리

로그인/회원가입 폼은 훅으로 분리되어 있었으나, 이메일 인증만 컴포넌트에 로직이 직접 들어있었음:
- `useLoginForm.ts` ← LoginForm.tsx
- `useSignupForm.ts` ← SignupForm.tsx
- ~~없음~~ ← EmailVerifyForm.tsx

`useEmailVerifyForm.ts` 훅을 새로 만들어서 동일한 패턴으로 통일:
- `EmailVerifyForm.tsx`: 94줄 → 39줄 (UI만 담당)
- `useEmailVerifyForm.ts`: 폼 설정, 재전송 핸들러, 인증 핸들러, 에러 처리 담당

## 이슈 번호

close #26

## 스크린샷 (선택)

