### PR TITLE
[Feat][#33] step-1 증거 업로드 api 연결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'ansimon-storage-prod.s3.ap-northeast-2.amazonaws.com',
       },
+      {
+        protocol: 'https',
+        hostname: 's3.ap-northeast-2.amazonaws.com',
+      },
     ],
   },
   turbopack: {

--- a/src/api/evidence.ts
+++ b/src/api/evidence.ts
@@ -1,0 +1,279 @@
+import { axiosInstance } from './axiosInstance';
+import type {
+  EvidencePresignedUrlRequest,
+  EvidencePresignedUrlResponse,
+  DeleteEvidenceRequest,
+  UpdateEvidenceFilenameRequest,
+  UpdateEvidenceFilenameResponse,
+  // MESSAGE
+  MessageRegisterRequest,
+  MessageRegisterListResponse,
+  MessagePreviewListResponse,
+  MessageDetailListResponse,
+  MessageOriginal,
+  // VOICE
+  VoiceRegisterRequest,
+  VoiceRegisterListResponse,
+  VoicePreviewListResponse,
+  VoiceDetailListResponse,
+  VoiceOriginal,
+  // TRACKING
+  TrackingRegisterRequest,
+  TrackingRegisterListResponse,
+  TrackingPreviewListResponse,
+  TrackingDetailListResponse,
+  TrackingOriginal,
+  // REPORT_RECORD
+  ReportRecordRegisterRequest,
+  ReportRecordRegisterListResponse,
+  ReportRecordPreviewListResponse,
+  ReportRecordDetailListResponse,
+  ReportRecordOriginal,
+  // INCIDENT_LOG
+  IncidentLogFileRegisterRequest,
+  IncidentLogFileRegisterListResponse,
+  IncidentLogPreviewListResponse,
+  IncidentLogDetailListResponse,
+  IncidentLogFileOriginal,
+  IncidentLogFormDataUploadRequest,
+  IncidentLogFormDataResponse,
+  IncidentLogFormDataUpdateRequest,
+} from '@/types/evidence';
+
+// ─── 공통 ───────────────────────────────────────────────
+
+// Presigned URL 발급 (모든 타입 공통)
+export async function getPresignedUrls(complaintId: string, payload: EvidencePresignedUrlRequest) {
+  const res = await axiosInstance.post<EvidencePresignedUrlResponse>(
+    `/api/v1/evidences/${complaintId}/presigned-url`,
+    payload,
+  );
+  return res.data;
+}
+
+// S3 직접 업로드 (presigned URL 사용, 인증 토큰 불필요)
+export async function uploadToS3(presignedUrl: string, file: File) {
+  await fetch(presignedUrl, {
+    method: 'PUT',
+    body: file,
+    headers: { 'Content-Type': file.type },
+  });
+}
+
+// 증거 삭제 (모든 타입 공통)
+export async function deleteEvidences(payload: DeleteEvidenceRequest) {
+  await axiosInstance.delete('/api/v1/evidences', { data: payload });
+}
+
+// 파일명 수정 (모든 타입 공통)
+export async function updateEvidenceFilename(
+  evidenceId: string,
+  payload: UpdateEvidenceFilenameRequest,
+) {
+  const res = await axiosInstance.patch<UpdateEvidenceFilenameResponse>(
+    `/api/v1/evidences/${evidenceId}/filename`,
+    payload,
+  );
+  return res.data;
+}
+
+// ─── MESSAGE ────────────────────────────────────────────
+
+export async function registerMessages(complaintId: string, payload: MessageRegisterRequest) {
+  const res = await axiosInstance.post<MessageRegisterListResponse>(
+    `/api/v1/${complaintId}/evidences/messages/register`,
+    payload,
+  );
+  return res.data;
+}
+
+export async function getMessagePreviews(complaintId: string, limit?: number) {
+  const res = await axiosInstance.get<MessagePreviewListResponse>(
+    `/api/v1/${complaintId}/evidences/messages/previews`,
+    { params: { limit } },
+  );
+  return res.data;
+}
+
+export async function getMessageDetails(complaintId: string, limit?: number) {
+  const res = await axiosInstance.get<MessageDetailListResponse>(
+    `/api/v1/${complaintId}/evidences/messages/details`,
+    { params: { limit } },
+  );
+  return res.data;
+}
+
+export async function getMessageOriginal(messageId: string) {
+  const res = await axiosInstance.get<MessageOriginal>(
+    `/api/v1/evidence/message/${messageId}/original`,
+  );
+  return res.data;
+}
+
+// ─── VOICE ──────────────────────────────────────────────
+
+export async function registerVoices(complaintId: string, payload: VoiceRegisterRequest) {
+  const res = await axiosInstance.post<VoiceRegisterListResponse>(
+    `/api/v1/${complaintId}/evidences/voices/register`,
+    payload,
+  );
+  return res.data;
+}
+
+export async function getVoicePreviews(complaintId: string, limit?: number) {
+  const res = await axiosInstance.get<VoicePreviewListResponse>(
+    `/api/v1/${complaintId}/evidences/voices/previews`,
+    { params: { limit } },
+  );
+  return res.data;
+}
+
+export async function getVoiceDetails(complaintId: string, limit?: number) {
+  const res = await axiosInstance.get<VoiceDetailListResponse>(
+    `/api/v1/${complaintId}/evidences/voices/details`,
+    { params: { limit } },
+  );
+  return res.data;
+}
+
+export async function getVoiceOriginal(voiceId: string) {
+  const res = await axiosInstance.get<VoiceOriginal>(`/api/v1/evidence/voice/${voiceId}/original`);
+  return res.data;
+}
+
+// ─── TRACKING ───────────────────────────────────────────
+
+export async function registerTrackings(complaintId: string, payload: TrackingRegisterRequest) {
+  const res = await axiosInstance.post<TrackingRegisterListResponse>(
+    `/api/v1/${complaintId}/evidences/trackings/register`,
+    payload,
+  );
+  return res.data;
+}
+
+export async function getTrackingPreviews(complaintId: string, limit?: number) {
+  const res = await axiosInstance.get<TrackingPreviewListResponse>(
+    `/api/v1/${complaintId}/evidences/trackings/previews`,
+    { params: { limit } },
+  );
+  return res.data;
+}
+
+export async function getTrackingDetails(complaintId: string, limit?: number) {
+  const res = await axiosInstance.get<TrackingDetailListResponse>(
+    `/api/v1/${complaintId}/evidences/trackings/details`,
+    { params: { limit } },
+  );
+  return res.data;
+}
+
+export async function getTrackingOriginal(trackingId: string) {
+  const res = await axiosInstance.get<TrackingOriginal>(
+    `/api/v1/evidence/tracking/${trackingId}/original`,
+  );
+  return res.data;
+}
+
+// ─── REPORT_RECORD ──────────────────────────────────────
+
+export async function registerReportRecords(
+  complaintId: string,
+  payload: ReportRecordRegisterRequest,
+) {
+  const res = await axiosInstance.post<ReportRecordRegisterListResponse>(
+    `/api/v1/${complaintId}/evidences/report-records/register`,
+    payload,
+  );
+  return res.data;
+}
+
+export async function getReportRecordPreviews(complaintId: string, limit?: number) {
+  const res = await axiosInstance.get<ReportRecordPreviewListResponse>(
+    `/api/v1/${complaintId}/evidences/report-records/previews`,
+    { params: { limit } },
+  );
+  return res.data;
+}
+
+export async function getReportRecordDetails(complaintId: string, limit?: number) {
+  const res = await axiosInstance.get<ReportRecordDetailListResponse>(
+    `/api/v1/${complaintId}/evidences/report-records/details`,
+    { params: { limit } },
+  );
+  return res.data;
+}
+
+export async function getReportRecordOriginal(reportRecordId: string) {
+  const res = await axiosInstance.get<ReportRecordOriginal>(
+    `/api/v1/evidence/report-record/${reportRecordId}/original`,
+  );
+  return res.data;
+}
+
+// ─── INCIDENT_LOG ───────────────────────────────────────
+
+// 파일 업로드 방식
+export async function registerIncidentLogFiles(
+  complaintId: string,
+  payload: IncidentLogFileRegisterRequest,
+) {
+  const res = await axiosInstance.post<IncidentLogFileRegisterListResponse>(
+    `/api/v1/${complaintId}/evidences/incident-logs/file/register`,
+    payload,
+  );
+  return res.data;
+}
+
+// 폼 데이터 방식
+export async function uploadIncidentLogFormData(
+  complaintId: string,
+  payload: IncidentLogFormDataUploadRequest,
+) {
+  const res = await axiosInstance.post<IncidentLogFormDataResponse>(
+    `/api/v1/${complaintId}/evidences/incident-logs/form-data`,
+    payload,
+  );
+  return res.data;
+}
+
+export async function getIncidentLogFormData(incidentLogId: string) {
+  const res = await axiosInstance.get<IncidentLogFormDataResponse>(
+    `/api/v1/evidence/incident-log-form-data/${incidentLogId}`,
+  );
+  return res.data;
+}
+
+export async function updateIncidentLogFormData(
+  incidentLogId: string,
+  payload: IncidentLogFormDataUpdateRequest,
+) {
+  const res = await axiosInstance.patch<IncidentLogFormDataResponse>(
+    `/api/v1/evidences/incident-logs/form-data/${incidentLogId}`,
+    payload,
+  );
+  return res.data;
+}
+
+// 공통 조회
+export async function getIncidentLogPreviews(complaintId: string, limit?: number) {
+  const res = await axiosInstance.get<IncidentLogPreviewListResponse>(
+    `/api/v1/${complaintId}/evidences/incident-logs/previews`,
+    { params: { limit } },
+  );
+  return res.data;
+}
+
+export async function getIncidentLogDetails(complaintId: string, limit?: number) {
+  const res = await axiosInstance.get<IncidentLogDetailListResponse>(
+    `/api/v1/${complaintId}/evidences/incident-logs/details`,
+    { params: { limit } },
+  );
+  return res.data;
+}
+
+export async function getIncidentLogFileOriginal(incidentLogId: string) {
+  const res = await axiosInstance.get<IncidentLogFileOriginal>(
+    `/api/v1/evidence/incident-log-file/${incidentLogId}/original`,
+  );
+  return res.data;
+}

--- a/src/api/evidence.ts
+++ b/src/api/evidence.ts
@@ -42,7 +42,7 @@ import type {
 
 // ─── 공통 ───────────────────────────────────────────────
 
-// Presigned URL 발급 (모든 타입 공통)
+/** Presigned URL 발급 — 모든 타입 공통, S3 업로드 URL을 받음 */
 export async function getPresignedUrls(complaintId: string, payload: EvidencePresignedUrlRequest) {
   const res = await axiosInstance.post<EvidencePresignedUrlResponse>(
     `/api/v1/evidences/${complaintId}/presigned-url`,
@@ -51,7 +51,7 @@ export async function getPresignedUrls(complaintId: string, payload: EvidencePre
   return res.data;
 }
 
-// S3 직접 업로드 (presigned URL 사용, 인증 토큰 불필요)
+/** S3 직접 업로드 — presigned URL 사용, 인증 토큰 불필요 (fetch) */
 export async function uploadToS3(presignedUrl: string, file: File) {
   await fetch(presignedUrl, {
     method: 'PUT',
@@ -60,12 +60,12 @@ export async function uploadToS3(presignedUrl: string, file: File) {
   });
 }
 
-// 증거 삭제 (모든 타입 공통)
+/** 증거 삭제 — 모든 타입 공통, ID 배열로 일괄 삭제 */
 export async function deleteEvidences(payload: DeleteEvidenceRequest) {
   await axiosInstance.delete('/api/v1/evidences', { data: payload });
 }
 
-// 파일명 수정 (모든 타입 공통)
+/** 파일명 수정 — 모든 타입 공통 */
 export async function updateEvidenceFilename(
   evidenceId: string,
   payload: UpdateEvidenceFilenameRequest,
@@ -77,8 +77,9 @@ export async function updateEvidenceFilename(
   return res.data;
 }
 
-// ─── MESSAGE ────────────────────────────────────────────
+// ─── MESSAGE (메신저/문자/DM) ───────────────────────────
 
+/** S3 업로드 완료 후 서버에 등록 */
 export async function registerMessages(complaintId: string, payload: MessageRegisterRequest) {
   const res = await axiosInstance.post<MessageRegisterListResponse>(
     `/api/v1/${complaintId}/evidences/messages/register`,
@@ -87,6 +88,7 @@ export async function registerMessages(complaintId: string, payload: MessageRegi
   return res.data;
 }
 
+/** 프리뷰 목록 (thumbnail_url만 포함) */
 export async function getMessagePreviews(complaintId: string, limit?: number) {
   const res = await axiosInstance.get<MessagePreviewListResponse>(
     `/api/v1/${complaintId}/evidences/messages/previews`,
@@ -95,6 +97,7 @@ export async function getMessagePreviews(complaintId: string, limit?: number) {
   return res.data;
 }
 
+/** 상세 목록 (filename, size_bytes 등 포함) */
 export async function getMessageDetails(complaintId: string, limit?: number) {
   const res = await axiosInstance.get<MessageDetailListResponse>(
     `/api/v1/${complaintId}/evidences/messages/details`,
@@ -103,6 +106,7 @@ export async function getMessageDetails(complaintId: string, limit?: number) {
   return res.data;
 }
 
+/** 원본 파일 정보 + 다운로드 URL */
 export async function getMessageOriginal(messageId: string) {
   const res = await axiosInstance.get<MessageOriginal>(
     `/api/v1/evidence/message/${messageId}/original`,
@@ -110,8 +114,9 @@ export async function getMessageOriginal(messageId: string) {
   return res.data;
 }
 
-// ─── VOICE ──────────────────────────────────────────────
+// ─── VOICE (통화/음성) ──────────────────────────────────
 
+/** S3 업로드 완료 후 서버에 등록 */
 export async function registerVoices(complaintId: string, payload: VoiceRegisterRequest) {
   const res = await axiosInstance.post<VoiceRegisterListResponse>(
     `/api/v1/${complaintId}/evidences/voices/register`,
@@ -120,6 +125,7 @@ export async function registerVoices(complaintId: string, payload: VoiceRegister
   return res.data;
 }
 
+/** 프리뷰 목록 (filename, duration_seconds 포함) */
 export async function getVoicePreviews(complaintId: string, limit?: number) {
   const res = await axiosInstance.get<VoicePreviewListResponse>(
     `/api/v1/${complaintId}/evidences/voices/previews`,
@@ -128,6 +134,7 @@ export async function getVoicePreviews(complaintId: string, limit?: number) {
   return res.data;
 }
 
+/** 상세 목록 */
 export async function getVoiceDetails(complaintId: string, limit?: number) {
   const res = await axiosInstance.get<VoiceDetailListResponse>(
     `/api/v1/${complaintId}/evidences/voices/details`,
@@ -136,13 +143,15 @@ export async function getVoiceDetails(complaintId: string, limit?: number) {
   return res.data;
 }
 
+/** 원본 파일 정보 + 다운로드 URL */
 export async function getVoiceOriginal(voiceId: string) {
   const res = await axiosInstance.get<VoiceOriginal>(`/api/v1/evidence/voice/${voiceId}/original`);
   return res.data;
 }
 
-// ─── TRACKING ───────────────────────────────────────────
+// ─── TRACKING (접근/추적 흔적) ──────────────────────────
 
+/** S3 업로드 완료 후 서버에 등록 */
 export async function registerTrackings(complaintId: string, payload: TrackingRegisterRequest) {
   const res = await axiosInstance.post<TrackingRegisterListResponse>(
     `/api/v1/${complaintId}/evidences/trackings/register`,
@@ -151,6 +160,7 @@ export async function registerTrackings(complaintId: string, payload: TrackingRe
   return res.data;
 }
 
+/** 프리뷰 목록 (thumbnail_url, duration_seconds 포함) */
 export async function getTrackingPreviews(complaintId: string, limit?: number) {
   const res = await axiosInstance.get<TrackingPreviewListResponse>(
     `/api/v1/${complaintId}/evidences/trackings/previews`,
@@ -159,6 +169,7 @@ export async function getTrackingPreviews(complaintId: string, limit?: number) {
   return res.data;
 }
 
+/** 상세 목록 */
 export async function getTrackingDetails(complaintId: string, limit?: number) {
   const res = await axiosInstance.get<TrackingDetailListResponse>(
     `/api/v1/${complaintId}/evidences/trackings/details`,
@@ -167,6 +178,7 @@ export async function getTrackingDetails(complaintId: string, limit?: number) {
   return res.data;
 }
 
+/** 원본 파일 정보 + 다운로드 URL */
 export async function getTrackingOriginal(trackingId: string) {
   const res = await axiosInstance.get<TrackingOriginal>(
     `/api/v1/evidence/tracking/${trackingId}/original`,
@@ -174,8 +186,9 @@ export async function getTrackingOriginal(trackingId: string) {
   return res.data;
 }
 
-// ─── REPORT_RECORD ──────────────────────────────────────
+// ─── REPORT_RECORD (신고/상담기록) ──────────────────────
 
+/** S3 업로드 완료 후 서버에 등록 */
 export async function registerReportRecords(
   complaintId: string,
   payload: ReportRecordRegisterRequest,
@@ -187,6 +200,7 @@ export async function registerReportRecords(
   return res.data;
 }
 
+/** 프리뷰 목록 (filename, size_bytes 포함) */
 export async function getReportRecordPreviews(complaintId: string, limit?: number) {
   const res = await axiosInstance.get<ReportRecordPreviewListResponse>(
     `/api/v1/${complaintId}/evidences/report-records/previews`,
@@ -195,6 +209,7 @@ export async function getReportRecordPreviews(complaintId: string, limit?: numbe
   return res.data;
 }
 
+/** 상세 목록 */
 export async function getReportRecordDetails(complaintId: string, limit?: number) {
   const res = await axiosInstance.get<ReportRecordDetailListResponse>(
     `/api/v1/${complaintId}/evidences/report-records/details`,
@@ -203,6 +218,7 @@ export async function getReportRecordDetails(complaintId: string, limit?: number
   return res.data;
 }
 
+/** 원본 파일 정보 + 다운로드 URL */
 export async function getReportRecordOriginal(reportRecordId: string) {
   const res = await axiosInstance.get<ReportRecordOriginal>(
     `/api/v1/evidence/report-record/${reportRecordId}/original`,
@@ -210,9 +226,9 @@ export async function getReportRecordOriginal(reportRecordId: string) {
   return res.data;
 }
 
-// ─── INCIDENT_LOG ───────────────────────────────────────
+// ─── INCIDENT_LOG (사건일지) ────────────────────────────
 
-// 파일 업로드 방식
+/** 파일 업로드 방식 — S3 업로드 완료 후 서버에 등록 */
 export async function registerIncidentLogFiles(
   complaintId: string,
   payload: IncidentLogFileRegisterRequest,
@@ -224,7 +240,7 @@ export async function registerIncidentLogFiles(
   return res.data;
 }
 
-// 폼 데이터 방식
+/** 폼 데이터 방식 — 날짜, 장소, 상황 등 직접 입력 */
 export async function uploadIncidentLogFormData(
   complaintId: string,
   payload: IncidentLogFormDataUploadRequest,
@@ -236,6 +252,7 @@ export async function uploadIncidentLogFormData(
   return res.data;
 }
 
+/** 폼 데이터 조회 */
 export async function getIncidentLogFormData(incidentLogId: string) {
   const res = await axiosInstance.get<IncidentLogFormDataResponse>(
     `/api/v1/evidence/incident-log-form-data/${incidentLogId}`,
@@ -243,6 +260,7 @@ export async function getIncidentLogFormData(incidentLogId: string) {
   return res.data;
 }
 
+/** 폼 데이터 수정 (Partial 업데이트) */
 export async function updateIncidentLogFormData(
   incidentLogId: string,
   payload: IncidentLogFormDataUpdateRequest,
@@ -254,7 +272,7 @@ export async function updateIncidentLogFormData(
   return res.data;
 }
 
-// 공통 조회
+/** 프리뷰 목록 (FILE + FORM_DATA 혼합) */
 export async function getIncidentLogPreviews(complaintId: string, limit?: number) {
   const res = await axiosInstance.get<IncidentLogPreviewListResponse>(
     `/api/v1/${complaintId}/evidences/incident-logs/previews`,
@@ -263,6 +281,7 @@ export async function getIncidentLogPreviews(complaintId: string, limit?: number
   return res.data;
 }
 
+/** 상세 목록 */
 export async function getIncidentLogDetails(complaintId: string, limit?: number) {
   const res = await axiosInstance.get<IncidentLogDetailListResponse>(
     `/api/v1/${complaintId}/evidences/incident-logs/details`,
@@ -271,6 +290,7 @@ export async function getIncidentLogDetails(complaintId: string, limit?: number)
   return res.data;
 }
 
+/** 원본 파일 정보 + 다운로드 URL (파일 업로드 방식만) */
 export async function getIncidentLogFileOriginal(incidentLogId: string) {
   const res = await axiosInstance.get<IncidentLogFileOriginal>(
     `/api/v1/evidence/incident-log-file/${incidentLogId}/original`,

--- a/src/app/my-space/case/components/StepCollect.tsx
+++ b/src/app/my-space/case/components/StepCollect.tsx
@@ -1,5 +1,5 @@
 import { EvidenceCard } from './evidence/EvidenceCard';
-import type { EvidenceType } from './evidence/constants';
+import type { EvidenceType } from '@/types/evidence';
 
 /** 왼쪽: 이미지 프리뷰 카드 */
 const LEFT_TYPES: EvidenceType[] = ['MESSAGE', 'TRACKING'];
@@ -7,20 +7,24 @@ const LEFT_TYPES: EvidenceType[] = ['MESSAGE', 'TRACKING'];
 /** 오른쪽: 파일 프리뷰 카드 */
 const RIGHT_TYPES: EvidenceType[] = ['VOICE', 'REPORT_RECORD', 'INCIDENT_LOG'];
 
-export function StepCollect() {
+interface StepCollectProps {
+  complaintId: string | undefined;
+}
+
+export function StepCollect({ complaintId }: StepCollectProps) {
   return (
     <div className="flex gap-6">
       {/* 왼쪽 컬럼 — 이미지 프리뷰 */}
       <div className="flex flex-1 flex-col gap-6">
         {LEFT_TYPES.map((type) => (
-          <EvidenceCard key={type} type={type} />
+          <EvidenceCard key={type} type={type} complaintId={complaintId} />
         ))}
       </div>
 
       {/* 오른쪽 컬럼 — 파일 프리뷰 */}
       <div className="flex flex-1 flex-col gap-6">
         {RIGHT_TYPES.map((type) => (
-          <EvidenceCard key={type} type={type} />
+          <EvidenceCard key={type} type={type} complaintId={complaintId} />
         ))}
       </div>
     </div>

--- a/src/app/my-space/case/components/evidence/EvidenceCard.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceCard.tsx
@@ -38,9 +38,11 @@ export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps
 
   const items = data?.items ?? [];
   const totalCount = data?.totalCount ?? 0;
+  const isFull = totalCount >= config.maxFiles;
 
   /** 파일 추가 — 프론트 검증 후 업로드 mutation 호출 */
   const handleFilesAdd = async (newFiles: File[]) => {
+    if (isFull) return; // 개수 초과 시 업로드 차단
     const valid = await filterValidFiles(newFiles, config, totalCount);
     if (valid.length > 0) upload.mutate(valid);
   };
@@ -86,7 +88,7 @@ export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps
         <span className="rounded-full bg-gray-100 px-3 py-1">
           {totalCount}/{config.maxFiles}개
         </span>
-        <Button color="secondary" size="lg" onClick={openFilePicker}>
+        <Button color="secondary" size="lg" onClick={openFilePicker} disabled={isFull}>
           <span className="flex items-center gap-2">
             <CommitOutlineIcon className="h-6 w-6" />
             증거 업로드

--- a/src/app/my-space/case/components/evidence/EvidenceCard.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceCard.tsx
@@ -1,15 +1,13 @@
 'use client';
 
-import { useRef } from 'react';
 import Image from 'next/image';
 import CommitOutlineIcon from '@/assets/icons/CommitOutlineIcon.svg';
 import HelpCircleOutlineIcon from '@/assets/icons/HelpCircleOutlineIcon.svg';
 import { Button } from '@/components/Button';
+import { Modal } from '@/components/modals/Modal';
 import { EvidenceContent } from './EvidenceContent';
 import type { EvidenceType } from '@/types/evidence';
-import { EVIDENCE_CONFIG } from './constants';
-import { filterValidFiles } from './validate';
-import { useEvidencePreviews, useUploadEvidence, useDeleteEvidence } from '../../hooks/useEvidence';
+import { useEvidenceCard } from '../../hooks/useEvidenceCard';
 
 interface EvidenceCardProps {
   /** 증거 타입 (MESSAGE, VOICE 등) */
@@ -28,32 +26,21 @@ interface EvidenceCardProps {
  * - Footer: 개수 뱃지 + 업로드 버튼
  */
 export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps) {
-  const config = EVIDENCE_CONFIG[type];
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  // React Query 훅
-  const { data } = useEvidencePreviews(complaintId, type);
-  const upload = useUploadEvidence(complaintId, type);
-  const remove = useDeleteEvidence(complaintId, type);
-
-  const items = data?.items ?? [];
-  const totalCount = data?.totalCount ?? 0;
-  const isFull = totalCount >= config.maxFiles;
-
-  /** 파일 추가 — 프론트 검증 후 업로드 mutation 호출 */
-  const handleFilesAdd = async (newFiles: File[]) => {
-    if (isFull) return; // 개수 초과 시 업로드 차단
-    const valid = await filterValidFiles(newFiles, config, totalCount);
-    if (valid.length > 0) upload.mutate(valid);
-  };
-
-  /** 증거 삭제 */
-  const handleRemove = (id: string) => {
-    remove.mutate([id]);
-  };
-
-  /** hidden input 트리거 */
-  const openFilePicker = () => inputRef.current?.click();
+  const {
+    inputRef,
+    config,
+    items,
+    totalCount,
+    isFull,
+    isUploading,
+    deleteModalOpen,
+    setDeleteModalOpen,
+    handleFilesAdd,
+    handleRemove,
+    confirmDelete,
+    cancelDelete,
+    openFilePicker,
+  } = useEvidenceCard(complaintId, type);
 
   return (
     <div
@@ -80,7 +67,7 @@ export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps
         onFilesAdd={handleFilesAdd}
         onRemove={handleRemove}
         onClickUpload={openFilePicker}
-        isUploading={upload.isPending}
+        isUploading={isUploading}
       />
 
       {/* Footer */}
@@ -108,6 +95,28 @@ export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps
         }}
         className="hidden"
       />
+
+      {/* 삭제 확인 모달 */}
+      <Modal.Root open={deleteModalOpen} onOpenChange={setDeleteModalOpen}>
+        <Modal.Header
+          title="증거 삭제"
+          subTitle={
+            <>
+              삭제된 증거는 다시 되돌릴 수 없어요.
+              <br />
+              정말 삭제하시겠어요?
+            </>
+          }
+        />
+        <Modal.Footer direction="row" full>
+          <Button color="secondary" size="xl" onClick={cancelDelete}>
+            취소하기
+          </Button>
+          <Button color="danger" size="xl" onClick={confirmDelete}>
+            삭제하기
+          </Button>
+        </Modal.Footer>
+      </Modal.Root>
     </div>
   );
 }

--- a/src/app/my-space/case/components/evidence/EvidenceCard.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceCard.tsx
@@ -55,7 +55,7 @@ export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps
 
   return (
     <div
-      className={`flex min-h-40 flex-col gap-6 rounded-2xl border border-gray-200 px-7 py-6 shadow-[0px_20px_50px_-5px_#4040400D] ${items.length === 0 ? 'flex-1' : ''} ${className ?? ''}`}
+      className={`flex min-h-40 flex-col gap-6 rounded-2xl border border-gray-200 px-7 py-6 shadow-[0px_20px_50px_-5px_#4040400D] transition-all duration-300 ${items.length === 0 ? 'flex-1' : ''} ${className ?? ''}`}
     >
       {/* Header */}
       <div className="flex items-center gap-3">

--- a/src/app/my-space/case/components/evidence/EvidenceCard.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceCard.tsx
@@ -1,18 +1,21 @@
 'use client';
 
-import { useState, useRef } from 'react';
+import { useRef } from 'react';
 import Image from 'next/image';
 import CommitOutlineIcon from '@/assets/icons/CommitOutlineIcon.svg';
 import HelpCircleOutlineIcon from '@/assets/icons/HelpCircleOutlineIcon.svg';
 import { Button } from '@/components/Button';
 import { EvidenceContent } from './EvidenceContent';
-import type { EvidenceType } from './constants';
+import type { EvidenceType } from '@/types/evidence';
 import { EVIDENCE_CONFIG } from './constants';
 import { filterValidFiles } from './validate';
+import { useEvidencePreviews, useUploadEvidence, useDeleteEvidence } from '../../hooks/useEvidence';
 
 interface EvidenceCardProps {
   /** 증거 타입 (MESSAGE, VOICE 등) */
   type: EvidenceType;
+  /** 고소장 ID (React Query 훅에 전달) */
+  complaintId: string | undefined;
   /** 외부에서 전달하는 추가 스타일 */
   className?: string;
 }
@@ -23,36 +26,36 @@ interface EvidenceCardProps {
  * - Header: 아이콘 + 타이틀 + 설명
  * - Contents: EvidenceContent (드래그앤드롭/클릭/프리뷰)
  * - Footer: 개수 뱃지 + 업로드 버튼
- *
- * 파일 선택 input을 하나만 소유하며,
- * 빈 상태 클릭(EvidenceContent)과 푸터 버튼 모두 같은 input을 트리거합니다.
  */
-export function EvidenceCard({ type, className }: EvidenceCardProps) {
+export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps) {
   const config = EVIDENCE_CONFIG[type];
-  // TODO: API 연결 시 로컬 state → React Query(useEvidence 훅)로 교체
-  // - files: useQuery로 서버 증거 목록 조회
-  // - handleFilesAdd: useMutation(presigned URL → S3 PUT → register)
-  // - handleFileRemove: useMutation(DELETE /evidences/:id)
-  const [files, setFiles] = useState<File[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  /** 파일 추가 — 타입·크기·영상길이 검증 후 state에 추가 */
+  // React Query 훅
+  const { data } = useEvidencePreviews(complaintId, type);
+  const upload = useUploadEvidence(complaintId, type);
+  const remove = useDeleteEvidence(complaintId, type);
+
+  const items = data?.items ?? [];
+  const totalCount = data?.totalCount ?? 0;
+
+  /** 파일 추가 — 프론트 검증 후 업로드 mutation 호출 */
   const handleFilesAdd = async (newFiles: File[]) => {
-    const valid = await filterValidFiles(newFiles, config, files.length);
-    if (valid.length > 0) setFiles((prev) => [...prev, ...valid]);
+    const valid = await filterValidFiles(newFiles, config, totalCount);
+    if (valid.length > 0) upload.mutate(valid);
   };
 
-  /** 파일 삭제 */
-  const handleFileRemove = (index: number) => {
-    setFiles((prev) => prev.filter((_, i) => i !== index));
+  /** 증거 삭제 */
+  const handleRemove = (id: string) => {
+    remove.mutate([id]);
   };
 
-  /** hidden input 트리거 — 빈 상태 클릭, 푸터 버튼 모두 이 함수를 사용 */
+  /** hidden input 트리거 */
   const openFilePicker = () => inputRef.current?.click();
 
   return (
     <div
-      className={`flex min-h-40 flex-col gap-6 rounded-2xl border border-gray-200 px-7 py-6 shadow-[0px_20px_50px_-5px_#4040400D] ${files.length === 0 ? 'flex-1' : ''} ${className ?? ''}`}
+      className={`flex min-h-40 flex-col gap-6 rounded-2xl border border-gray-200 px-7 py-6 shadow-[0px_20px_50px_-5px_#4040400D] ${items.length === 0 ? 'flex-1' : ''} ${className ?? ''}`}
     >
       {/* Header */}
       <div className="flex items-center gap-3">
@@ -71,16 +74,17 @@ export function EvidenceCard({ type, className }: EvidenceCardProps) {
       {/* Contents */}
       <EvidenceContent
         previewType={config.previewType}
-        files={files}
+        items={items}
         onFilesAdd={handleFilesAdd}
-        onFileRemove={handleFileRemove}
+        onRemove={handleRemove}
         onClickUpload={openFilePicker}
+        isUploading={upload.isPending}
       />
 
       {/* Footer */}
       <div className="typo-btn-2text-gray-700 flex items-center justify-between">
         <span className="rounded-full bg-gray-100 px-3 py-1">
-          {files.length}/{config.maxFiles}개
+          {totalCount}/{config.maxFiles}개
         </span>
         <Button color="secondary" size="lg" onClick={openFilePicker}>
           <span className="flex items-center gap-2">
@@ -90,7 +94,7 @@ export function EvidenceCard({ type, className }: EvidenceCardProps) {
         </Button>
       </div>
 
-      {/* 파일 선택 input — 카드 내 input. 빈 상태 클릭 + 푸터 버튼 모두 이 input을 트리거 */}
+      {/* 파일 선택 input */}
       <input
         ref={inputRef}
         type="file"

--- a/src/app/my-space/case/components/evidence/EvidenceCard.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceCard.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/Button';
 import { EvidenceContent } from './EvidenceContent';
 import type { EvidenceType } from './constants';
 import { EVIDENCE_CONFIG } from './constants';
+import { filterValidFiles } from './validate';
 
 interface EvidenceCardProps {
   /** 증거 타입 (MESSAGE, VOICE 등) */
@@ -35,15 +36,11 @@ export function EvidenceCard({ type, className }: EvidenceCardProps) {
   const [files, setFiles] = useState<File[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  /** 파일 추가 — 개수·크기 제한 적용 후 state에 추가 */
+  /** 파일 추가 — 개수·타입·크기 제한 적용 후 state에 추가 */
   const handleFilesAdd = (newFiles: File[]) => {
     setFiles((prev) => {
-      const remaining = config.maxFiles - prev.length;
-      if (remaining <= 0) return prev;
-
-      const validFiles = newFiles.slice(0, remaining).filter((file) => file.size <= config.maxSize);
-
-      return [...prev, ...validFiles];
+      const valid = filterValidFiles(newFiles, config, prev.length);
+      return valid.length > 0 ? [...prev, ...valid] : prev;
     });
   };
 

--- a/src/app/my-space/case/components/evidence/EvidenceCard.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceCard.tsx
@@ -36,12 +36,10 @@ export function EvidenceCard({ type, className }: EvidenceCardProps) {
   const [files, setFiles] = useState<File[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  /** 파일 추가 — 개수·타입·크기 제한 적용 후 state에 추가 */
-  const handleFilesAdd = (newFiles: File[]) => {
-    setFiles((prev) => {
-      const valid = filterValidFiles(newFiles, config, prev.length);
-      return valid.length > 0 ? [...prev, ...valid] : prev;
-    });
+  /** 파일 추가 — 타입·크기·영상길이 검증 후 state에 추가 */
+  const handleFilesAdd = async (newFiles: File[]) => {
+    const valid = await filterValidFiles(newFiles, config, files.length);
+    if (valid.length > 0) setFiles((prev) => [...prev, ...valid]);
   };
 
   /** 파일 삭제 */

--- a/src/app/my-space/case/components/evidence/EvidenceContent.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceContent.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Spinner } from '@/components/Spinner';
 import { ImagePreview } from './ImagePreview';
 import { FilePreview } from './FilePreview';
+import type { EvidencePreviewItem } from '@/types/evidence';
 
 /** 프리뷰 표시 방식 */
 type PreviewType = 'image' | 'file';
@@ -11,12 +12,12 @@ type PreviewType = 'image' | 'file';
 interface EvidenceContentProps {
   /** 프리뷰 표시 방식 (image: 썸네일, file: 파일명+크기) */
   previewType?: PreviewType;
-  /** 현재 선택된 파일 목록 */
-  files: File[];
+  /** 서버에서 가져온 프리뷰 아이템 목록 */
+  items: EvidencePreviewItem[];
   /** 파일 추가 시 콜백 (드래그앤드롭) */
   onFilesAdd: (files: File[]) => void;
-  /** 파일 삭제 시 콜백 */
-  onFileRemove: (index: number) => void;
+  /** 증거 삭제 시 콜백 */
+  onRemove: (id: string) => void;
   /** 빈 상태 클릭 시 파일 선택 창을 여는 콜백 (EvidenceCard의 hidden input 트리거) */
   onClickUpload: () => void;
   /** 업로드 중 상태 */
@@ -29,17 +30,12 @@ interface EvidenceContentProps {
  * - 빈 상태: 드래그앤드롭 / 클릭으로 업로드 유도
  * - 로딩 상태: 스피너 표시
  * - 파일 있음: previewType에 따라 ImagePreview 또는 FilePreview 표시
- *
- * 파일 제한(accept, maxFiles, maxSize 등)은 증거 타입별로 다르므로
- * 상위 컴포넌트(EvidenceCard)에서 EVIDENCE_CONFIG 상수를 통해 주입받습니다.
- * 파일 선택 input도 EvidenceCard에서 관리하며, 빈 상태 클릭 시 onClickUpload로 트리거합니다.
- * @see {@link ../constants.ts} EVIDENCE_CONFIG
  */
 export function EvidenceContent({
   previewType = 'file',
-  files,
+  items,
   onFilesAdd,
-  onFileRemove,
+  onRemove,
   onClickUpload,
   isUploading = false,
 }: EvidenceContentProps) {
@@ -65,12 +61,12 @@ export function EvidenceContent({
     setIsDragOver(false);
   };
 
-  const hasFiles = files.length > 0;
+  const hasItems = items.length > 0;
 
   return (
-    <div className={hasFiles ? '' : 'flex-1'}>
+    <div className={hasItems ? '' : 'flex-1'}>
       {/* 빈 상태 — 드래그앤드롭/클릭 영역 */}
-      {!hasFiles && (
+      {!hasItems && (
         <div
           onDrop={handleDrop}
           onDragOver={handleDragOver}
@@ -93,25 +89,25 @@ export function EvidenceContent({
         </div>
       )}
 
-      {/* 파일 있음 — 프리뷰 표시 */}
-      {hasFiles && (
+      {/* 프리뷰 표시 */}
+      {hasItems && (
         <div className={previewType === 'image' ? 'grid grid-cols-4 gap-2' : 'flex flex-col gap-2'}>
-          {files.map((file, index) =>
+          {items.map((item) =>
             previewType === 'image' ? (
-              // TODO: API 연결 후 file prop 대신 src(서버 URL)로 전환
               <ImagePreview
-                key={`${file.name}-${index}`}
-                file={file}
+                key={item.id}
+                src={item.thumbnailUrl}
+                alt={item.filename}
                 size="fill"
                 showFileName
-                onRemove={() => onFileRemove(index)}
+                onRemove={() => onRemove(item.id)}
               />
             ) : (
               <FilePreview
-                key={`${file.name}-${index}`}
-                name={file.name}
-                size={file.size}
-                onRemove={() => onFileRemove(index)}
+                key={item.id}
+                name={item.filename ?? '파일'}
+                size={item.sizeBytes ?? 0}
+                onRemove={() => onRemove(item.id)}
               />
             ),
           )}

--- a/src/app/my-space/case/components/evidence/EvidenceContent.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceContent.tsx
@@ -77,7 +77,7 @@ export function EvidenceContent({
           }`}
         >
           {isUploading ? (
-            <Spinner size="lg" label="파일 업로드 중" />
+            <Spinner size="lg" className="text-gray-400" label="파일 업로드 중" />
           ) : (
             <div className="flex flex-col items-center">
               <p className="typo-heading-4 text-gray-400">증거업로드</p>

--- a/src/app/my-space/case/components/evidence/EvidenceContent.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceContent.tsx
@@ -5,6 +5,7 @@ import { Spinner } from '@/components/Spinner';
 import { ImagePreview } from './ImagePreview';
 import { FilePreview } from './FilePreview';
 import type { EvidencePreviewItem } from '@/types/evidence';
+import { formatDuration } from '@/utils/format';
 
 /** 프리뷰 표시 방식 */
 type PreviewType = 'image' | 'file';
@@ -100,6 +101,7 @@ export function EvidenceContent({
                 alt={item.filename ?? `이미지 ${index + 1}`}
                 size="fill"
                 showFileName
+                duration={item.durationSeconds ? formatDuration(item.durationSeconds) : undefined}
                 onRemove={() => onRemove(item.id)}
               />
             ) : (

--- a/src/app/my-space/case/components/evidence/EvidenceContent.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceContent.tsx
@@ -92,12 +92,12 @@ export function EvidenceContent({
       {/* 프리뷰 표시 */}
       {hasItems && (
         <div className={previewType === 'image' ? 'grid grid-cols-4 gap-2' : 'flex flex-col gap-2'}>
-          {items.map((item) =>
+          {items.map((item, index) =>
             previewType === 'image' ? (
               <ImagePreview
                 key={item.id}
                 src={item.thumbnailUrl}
-                alt={item.filename}
+                alt={item.filename ?? `이미지 ${index + 1}`}
                 size="fill"
                 showFileName
                 onRemove={() => onRemove(item.id)}

--- a/src/app/my-space/case/components/evidence/FilePreview.tsx
+++ b/src/app/my-space/case/components/evidence/FilePreview.tsx
@@ -1,5 +1,6 @@
 import FileIcon from '@/assets/icons/FileIcon.svg';
 import TrashOutlineIcon from '@/assets/icons/TrashOutlineIcon.svg';
+import { formatFileSize } from '@/utils/format';
 
 interface FilePreviewProps {
   /** 파일명 */
@@ -17,8 +18,7 @@ interface FilePreviewProps {
  * - 이미지가 아닌 파일(PDF, 문서 등)용
  */
 export function FilePreview({ name, size, onRemove }: FilePreviewProps) {
-  const formattedSize =
-    size < 1024 * 1024 ? `${(size / 1024).toFixed(1)}KB` : `${(size / (1024 * 1024)).toFixed(1)}MB`;
+  const formattedSize = formatFileSize(size);
 
   return (
     <div className="bg-bg-2 flex w-full items-center gap-2 rounded-sm border border-gray-200 px-2 py-3">

--- a/src/app/my-space/case/components/evidence/ImagePreview.tsx
+++ b/src/app/my-space/case/components/evidence/ImagePreview.tsx
@@ -76,6 +76,7 @@ export function ImagePreview({
         src={hasError ? imageFallback : imgSrc}
         alt={imgAlt}
         fill
+        sizes="(max-width: 768px) 25vw, 152px"
         className="object-cover"
         onError={() => {
           if (!hasError) setHasError(true);

--- a/src/app/my-space/case/components/evidence/ImagePreview.tsx
+++ b/src/app/my-space/case/components/evidence/ImagePreview.tsx
@@ -103,17 +103,10 @@ export function ImagePreview({
         </div>
       )}
 
-      {/* 파일 개수 뱃지 */}
-      {showFileCount && (
+      {/* 우하단 뱃지 (파일 개수 또는 영상 길이) */}
+      {(showFileCount || duration) && (
         <span className="typo-body-8 absolute right-2 bottom-2 rounded-xs bg-gray-900/40 px-1.5 py-px text-white transition group-hover:opacity-0">
-          {showFileCount}
-        </span>
-      )}
-
-      {/* 영상 길이 */}
-      {duration && (
-        <span className="typo-body-8 absolute right-2 bottom-2 rounded-xs bg-gray-900/40 px-1.5 py-px text-white transition group-hover:opacity-0">
-          {duration}
+          {showFileCount ?? duration}
         </span>
       )}
     </div>

--- a/src/app/my-space/case/components/evidence/constants.ts
+++ b/src/app/my-space/case/components/evidence/constants.ts
@@ -12,6 +12,7 @@ export const EVIDENCE_CONFIG: Record<
     maxFiles: number;
     maxSize: number;
     accept: string;
+    mimeTypes?: string[];
     previewType: 'image' | 'file';
     title: string;
     description: string;
@@ -22,6 +23,7 @@ export const EVIDENCE_CONFIG: Record<
     maxFiles: 10,
     maxSize: 10 * 1024 * 1024, // 10MB
     accept: '.jpg,.jpeg,.png,.heic',
+    mimeTypes: ['image/jpeg', 'image/png', 'image/heic'],
     previewType: 'image',
     title: '메신저 / 문자 / DM',
     description: '대화 캡처(스크린샷), 대화내역 저장(내보내기), 차단 전후 메시지',
@@ -31,15 +33,17 @@ export const EVIDENCE_CONFIG: Record<
     maxFiles: 5,
     maxSize: 20 * 1024 * 1024, // 20MB
     accept: '.m4a,.mp3,.wav',
+    mimeTypes: ['audio/mp4', 'audio/mpeg', 'audio/wav'],
     previewType: 'file',
     title: '통화 · 음성',
-    description: '통화 기록(부재중 포함), 음성사서함, 통화 내용 녹음(당사자자 녹음)',
+    description: '통화 기록(부재중 포함), 음성사서함, 통화 내용 녹음(당사자 녹음)',
     icon: talkIcon,
   },
   TRACKING: {
     maxFiles: 3,
     maxSize: 500 * 1024 * 1024, // 500MB
     accept: '.mp4,.mov',
+    mimeTypes: ['video/mp4', 'video/quicktime'],
     previewType: 'image',
     title: '접근/추적 흔적',
     description: '찾아옴/대기/미행 장면 사진·영상, 차량 블랙박스, CCTV',
@@ -49,6 +53,12 @@ export const EVIDENCE_CONFIG: Record<
     maxFiles: 3,
     maxSize: 10 * 1024 * 1024, // 10MB
     accept: '.pdf,.hwp,.docx,.txt',
+    mimeTypes: [
+      'application/pdf',
+      'application/vnd.hancom.hwp', // 브라우저가 인식 못해 file.type이 "" → 확장자 폴백으로 처리
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'text/plain',
+    ],
     previewType: 'file',
     title: '신고 · 상담기록',
     description: '경찰 신고 내역, 상담기관 기록, 피해 진단서 (정신적/신체적 등)',
@@ -58,6 +68,12 @@ export const EVIDENCE_CONFIG: Record<
     maxFiles: 3,
     maxSize: 10 * 1024 * 1024, // 10MB
     accept: '.pdf,.hwp,.docx,.txt',
+    mimeTypes: [
+      'application/pdf',
+      'application/vnd.hancom.hwp', // 브라우저가 인식 못해 file.type이 "" → 확장자 폴백으로 처리
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'text/plain',
+    ],
     previewType: 'file',
     title: '사건 일지',
     description: '일어난 사건에 대한 내용을 작성한 기록',

--- a/src/app/my-space/case/components/evidence/constants.ts
+++ b/src/app/my-space/case/components/evidence/constants.ts
@@ -11,6 +11,7 @@ export const EVIDENCE_CONFIG: Record<
   {
     maxFiles: number;
     maxSize: number;
+    maxDuration?: number; // 초 단위, 영상·음성 타입만 사용
     accept: string;
     mimeTypes?: string[];
     previewType: 'image' | 'file';
@@ -32,6 +33,7 @@ export const EVIDENCE_CONFIG: Record<
   VOICE: {
     maxFiles: 5,
     maxSize: 20 * 1024 * 1024, // 20MB
+    maxDuration: 300, // 5분
     accept: '.m4a,.mp3,.wav',
     mimeTypes: ['audio/mp4', 'audio/mpeg', 'audio/wav'],
     previewType: 'file',
@@ -42,6 +44,7 @@ export const EVIDENCE_CONFIG: Record<
   TRACKING: {
     maxFiles: 3,
     maxSize: 500 * 1024 * 1024, // 500MB
+    maxDuration: 300, // 5분
     accept: '.mp4,.mov',
     mimeTypes: ['video/mp4', 'video/quicktime'],
     previewType: 'image',

--- a/src/app/my-space/case/components/evidence/validate.ts
+++ b/src/app/my-space/case/components/evidence/validate.ts
@@ -11,16 +11,52 @@ const isValidType = (file: File, config: EvidenceConfig): boolean => {
   return config.accept.split(',').includes(ext);
 };
 
-/** 새 파일 목록에서 유효한 파일만 필터링 (개수 → 타입 → 크기 순으로 검증) */
-export const filterValidFiles = (
+/** 영상/음성 파일의 재생 길이(초)를 반환. 메타데이터만 로드하므로 전체 파일을 읽지 않음 */
+const getMediaDuration = (file: File): Promise<number> => {
+  return new Promise((resolve, reject) => {
+    const video = document.createElement('video');
+    video.preload = 'metadata';
+    video.onloadedmetadata = () => {
+      URL.revokeObjectURL(video.src);
+      resolve(video.duration);
+    };
+    video.onerror = () => {
+      URL.revokeObjectURL(video.src);
+      reject(new Error('영상 메타데이터 로드 실패'));
+    };
+    video.src = URL.createObjectURL(file);
+  });
+};
+
+/** 새 파일 목록에서 유효한 파일만 필터링 (타입 → 크기 → 영상 길이 → 개수 순으로 검증) */
+export const filterValidFiles = async (
   newFiles: File[],
   config: EvidenceConfig,
   currentCount: number,
-): File[] => {
+): Promise<File[]> => {
   const remaining = config.maxFiles - currentCount;
   if (remaining <= 0) return [];
 
-  return newFiles
-    .filter((file) => isValidType(file, config) && file.size <= config.maxSize)
-    .slice(0, remaining); // 유효한 파일 중 남은 개수만큼만
+  // 타입 + 크기 검증 (동기)
+  const typeAndSizeValid = newFiles.filter(
+    (file) => isValidType(file, config) && file.size <= config.maxSize,
+  );
+
+  // 영상 길이 검증 (비동기, maxDuration이 있는 타입만)
+  let result = typeAndSizeValid;
+  if (config.maxDuration) {
+    const checks = await Promise.all(
+      typeAndSizeValid.map(async (file) => {
+        try {
+          const duration = await getMediaDuration(file);
+          return duration <= config.maxDuration!;
+        } catch {
+          return false; // 메타데이터 로드 실패 시 제외
+        }
+      }),
+    );
+    result = typeAndSizeValid.filter((_, i) => checks[i]);
+  }
+
+  return result.slice(0, remaining); // 유효한 파일 중 남은 개수만큼만
 };

--- a/src/app/my-space/case/components/evidence/validate.ts
+++ b/src/app/my-space/case/components/evidence/validate.ts
@@ -1,0 +1,26 @@
+import type { EVIDENCE_CONFIG } from './constants';
+
+type EvidenceConfig = (typeof EVIDENCE_CONFIG)[string];
+
+/** MIME type 또는 확장자로 파일 형식 검증 (드래그앤드롭은 input accept를 우회하므로 JS에서 재검증) */
+const isValidType = (file: File, config: EvidenceConfig): boolean => {
+  // 1차: MIME type 매칭
+  if (file.type && config.mimeTypes?.includes(file.type)) return true;
+  // 2차: MIME이 빈 문자열인 경우(.hwp 등) 확장자로 폴백
+  const ext = '.' + file.name.split('.').pop()?.toLowerCase();
+  return config.accept.split(',').includes(ext);
+};
+
+/** 새 파일 목록에서 유효한 파일만 필터링 (개수 → 타입 → 크기 순으로 검증) */
+export const filterValidFiles = (
+  newFiles: File[],
+  config: EvidenceConfig,
+  currentCount: number,
+): File[] => {
+  const remaining = config.maxFiles - currentCount;
+  if (remaining <= 0) return [];
+
+  return newFiles
+    .filter((file) => isValidType(file, config) && file.size <= config.maxSize)
+    .slice(0, remaining); // 유효한 파일 중 남은 개수만큼만
+};

--- a/src/app/my-space/case/components/evidence/validate.ts
+++ b/src/app/my-space/case/components/evidence/validate.ts
@@ -12,7 +12,7 @@ const isValidType = (file: File, config: EvidenceConfig): boolean => {
 };
 
 /** 영상/음성 파일의 재생 길이(초)를 반환. 메타데이터만 로드하므로 전체 파일을 읽지 않음 */
-const getMediaDuration = (file: File): Promise<number> => {
+export const getMediaDuration = (file: File): Promise<number> => {
   return new Promise((resolve, reject) => {
     const video = document.createElement('video');
     video.preload = 'metadata';

--- a/src/app/my-space/case/hooks/useComplaint.ts
+++ b/src/app/my-space/case/hooks/useComplaint.ts
@@ -2,7 +2,15 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getComplaint, updateComplaint } from '@/api/complaint';
 import type { UpdateComplaintPayload } from '@/types/complaint';
 
-// 고소장 조회 훅
+/**
+ * 고소장 조회 훅
+ *
+ * - complaintId가 있을 때만 요청 (enabled)
+ * - staleTime: 5분
+ * - 수정 성공 시 useUpdateComplaint의 invalidateQueries로 갱신
+ *
+ * @param complaintId - 고소장 ID (undefined이면 요청하지 않음)
+ */
 export function useComplaint(complaintId: string | undefined) {
   return useQuery({
     queryKey: ['complaint', complaintId],
@@ -12,7 +20,14 @@ export function useComplaint(complaintId: string | undefined) {
   });
 }
 
-// 고소장 수정 훅
+/**
+ * 고소장 수정 훅
+ *
+ * - 성공 시 고소장 조회 캐시 자동 갱신 (invalidateQueries)
+ *
+ * @param complaintId - 고소장 ID
+ * @returns useMutation — mutate(payload: UpdateComplaintPayload)로 호출
+ */
 export function useUpdateComplaint(complaintId: string | undefined) {
   const queryClient = useQueryClient();
 

--- a/src/app/my-space/case/hooks/useComplaint.ts
+++ b/src/app/my-space/case/hooks/useComplaint.ts
@@ -7,7 +7,8 @@ export function useComplaint(complaintId: string | undefined) {
   return useQuery({
     queryKey: ['complaint', complaintId],
     queryFn: () => getComplaint(complaintId!),
-    enabled: !!complaintId, // complaintId 없으면 요청 안 함
+    enabled: !!complaintId,
+    staleTime: 1000 * 60 * 5, // 5분간 캐시 유지
   });
 }
 

--- a/src/app/my-space/case/hooks/useEvidence.ts
+++ b/src/app/my-space/case/hooks/useEvidence.ts
@@ -31,6 +31,7 @@ import { getMediaDuration } from '../components/evidence/validate';
 
 // ─── query key ──────────────────────────────────────────
 
+/** React Query 캐시 키 팩토리. `['evidence', 'previews', complaintId, type]` 형태 */
 const evidenceKeys = {
   previews: (complaintId: string, type: EvidenceType) =>
     ['evidence', 'previews', complaintId, type] as const,
@@ -39,6 +40,12 @@ const evidenceKeys = {
 
 // ─── 타입별 detail → 통일 PreviewItem 변환 ─────────────
 
+/**
+ * 타입별 detail → 통일 PreviewItem 변환 매퍼
+ *
+ * - 각 타입마다 응답 필드명이 다름(message_id, voice_id 등) → 여기서 통일
+ * - preview 대신 detail API를 사용하여 filename, size_bytes 등 추가 필드를 함께 조회
+ */
 const fetchAndNormalize: Record<
   EvidenceType,
   (complaintId: string) => Promise<{ items: EvidencePreviewItem[]; totalCount: number }>
@@ -106,6 +113,11 @@ const fetchAndNormalize: Record<
 
 // ─── 타입별 register 함수 매핑 ──────────────────────────
 
+/**
+ * 타입별 register API 호출
+ *
+ * - presigned URL 응답의 evidenceId를 타입별 ID 필드명으로 매핑 (messageId, voiceId 등)
+ */
 const registerByType = async (
   type: EvidenceType,
   complaintId: string,
@@ -137,6 +149,17 @@ const registerByType = async (
 
 // ─── 프리뷰 조회 훅 ────────────────────────────────────
 
+/**
+ * 증거 목록 조회 훅
+ *
+ * - 타입별 detail API를 호출하고 EvidencePreviewItem[]로 정규화하여 반환
+ * - staleTime: 5분
+ * - 업로드/삭제 시 invalidateQueries로 갱신
+ *
+ * @param complaintId - 고소장 ID (undefined이면 요청하지 않음)
+ * @param type - 증거 타입 (MESSAGE, VOICE, TRACKING, REPORT_RECORD, INCIDENT_LOG)
+ * @returns `{ items: EvidencePreviewItem[], totalCount: number }`
+ */
 export function useEvidencePreviews(complaintId: string | undefined, type: EvidenceType) {
   return useQuery({
     queryKey: evidenceKeys.previews(complaintId!, type),
@@ -148,6 +171,18 @@ export function useEvidencePreviews(complaintId: string | undefined, type: Evide
 
 // ─── 업로드 훅 (presigned URL → S3 PUT → register) ─────
 
+/**
+ * 증거 파일 업로드 훅 (3단계 플로우)
+ *
+ * - Presigned URL 발급 → S3 PUT 업로드 → 서버 Register 순차 실행
+ * - VOICE/TRACKING은 업로드 전 getMediaDuration()으로 실제 재생 길이 측정
+ * - S3 PUT은 인증 토큰 없이 fetch 사용 (presigned URL 자체에 인증 포함)
+ * - 성공 시 invalidateQueries로 목록 자동 갱신
+ *
+ * @param complaintId - 고소장 ID
+ * @param type - 증거 타입
+ * @returns useMutation — mutate(files: File[])로 호출
+ */
 export function useUploadEvidence(complaintId: string | undefined, type: EvidenceType) {
   const queryClient = useQueryClient();
   const config = EVIDENCE_CONFIG[type];
@@ -197,6 +232,16 @@ export function useUploadEvidence(complaintId: string | undefined, type: Evidenc
 
 // ─── 삭제 훅 ────────────────────────────────────────────
 
+/**
+ * 증거 삭제 훅
+ *
+ * - 증거 ID 배열을 받아 일괄 삭제
+ * - 성공 시 invalidateQueries로 목록 자동 갱신
+ *
+ * @param complaintId - 고소장 ID
+ * @param type - 증거 타입
+ * @returns useMutation — mutate(evidenceIds: string[])로 호출
+ */
 export function useDeleteEvidence(complaintId: string | undefined, type: EvidenceType) {
   const queryClient = useQueryClient();
 

--- a/src/app/my-space/case/hooks/useEvidence.ts
+++ b/src/app/my-space/case/hooks/useEvidence.ts
@@ -1,0 +1,140 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getPresignedUrls,
+  uploadToS3,
+  deleteEvidences,
+  // 타입별 register
+  registerMessages,
+  registerVoices,
+  registerTrackings,
+  registerReportRecords,
+  registerIncidentLogFiles,
+  // 타입별 preview
+  getMessagePreviews,
+  getVoicePreviews,
+  getTrackingPreviews,
+  getReportRecordPreviews,
+  getIncidentLogPreviews,
+} from '@/api/evidence';
+import type { EvidenceType, PresignedUrlItemRequest } from '@/types/evidence';
+import { EVIDENCE_CONFIG } from '../components/evidence/constants';
+
+// ─── query key ──────────────────────────────────────────
+
+const evidenceKeys = {
+  previews: (complaintId: string, type: EvidenceType) =>
+    ['evidence', 'previews', complaintId, type] as const,
+  allPreviews: (complaintId: string) => ['evidence', 'previews', complaintId] as const,
+};
+
+// ─── 타입별 preview 조회 함수 매핑 ─────────────────────
+
+const previewFetchers: Record<
+  EvidenceType,
+  (complaintId: string, limit?: number) => Promise<{ total_count: number }>
+> = {
+  MESSAGE: getMessagePreviews,
+  VOICE: getVoicePreviews,
+  TRACKING: getTrackingPreviews,
+  REPORT_RECORD: getReportRecordPreviews,
+  INCIDENT_LOG: getIncidentLogPreviews,
+};
+
+// ─── 타입별 register 함수 매핑 ──────────────────────────
+
+const registerByType = async (
+  type: EvidenceType,
+  complaintId: string,
+  items: { evidenceId: string; filename: string }[],
+) => {
+  switch (type) {
+    case 'MESSAGE':
+      return registerMessages(complaintId, {
+        items: items.map((i) => ({ messageId: i.evidenceId, filename: i.filename })),
+      });
+    case 'VOICE':
+      return registerVoices(complaintId, {
+        items: items.map((i) => ({ voiceId: i.evidenceId, filename: i.filename })),
+      });
+    case 'TRACKING':
+      return registerTrackings(complaintId, {
+        items: items.map((i) => ({ trackingId: i.evidenceId, filename: i.filename })),
+      });
+    case 'REPORT_RECORD':
+      return registerReportRecords(complaintId, {
+        items: items.map((i) => ({ reportRecordId: i.evidenceId, filename: i.filename })),
+      });
+    case 'INCIDENT_LOG':
+      return registerIncidentLogFiles(complaintId, {
+        items: items.map((i) => ({ incidentLogId: i.evidenceId, filename: i.filename })),
+      });
+  }
+};
+
+// ─── 프리뷰 조회 훅 ────────────────────────────────────
+
+export function useEvidencePreviews(complaintId: string | undefined, type: EvidenceType) {
+  return useQuery({
+    queryKey: evidenceKeys.previews(complaintId!, type),
+    queryFn: () => previewFetchers[type](complaintId!),
+    enabled: !!complaintId,
+  });
+}
+
+// ─── 업로드 훅 (presigned URL → S3 PUT → register) ─────
+
+export function useUploadEvidence(complaintId: string | undefined, type: EvidenceType) {
+  const queryClient = useQueryClient();
+  const config = EVIDENCE_CONFIG[type];
+
+  return useMutation({
+    mutationFn: async (files: File[]) => {
+      // 1) presigned URL 발급
+      const presignedItems: PresignedUrlItemRequest[] = files.map((file, i) => ({
+        index: i,
+        filename: file.name,
+        contentType: file.type,
+        sizeBytes: file.size,
+        ...(config.maxDuration ? { durationSeconds: 0 } : {}), // TODO: 실제 duration 전달
+      }));
+
+      const { items: presignedUrls } = await getPresignedUrls(complaintId!, {
+        type,
+        items: presignedItems,
+      });
+
+      // 2) S3에 파일 업로드
+      await Promise.all(presignedUrls.map((presigned, i) => uploadToS3(presigned.url, files[i])));
+
+      // 3) 서버에 등록
+      return registerByType(
+        type,
+        complaintId!,
+        presignedUrls.map((p) => ({
+          evidenceId: p.evidence_id,
+          filename: p.filename,
+        })),
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: evidenceKeys.previews(complaintId!, type),
+      });
+    },
+  });
+}
+
+// ─── 삭제 훅 ────────────────────────────────────────────
+
+export function useDeleteEvidence(complaintId: string | undefined, type: EvidenceType) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (evidenceIds: string[]) => deleteEvidences({ type, evidenceIds }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: evidenceKeys.previews(complaintId!, type),
+      });
+    },
+  });
+}

--- a/src/app/my-space/case/hooks/useEvidence.ts
+++ b/src/app/my-space/case/hooks/useEvidence.ts
@@ -9,22 +9,22 @@ import {
   registerTrackings,
   registerReportRecords,
   registerIncidentLogFiles,
-  // 타입별 preview
-  getMessagePreviews,
-  getVoicePreviews,
-  getTrackingPreviews,
-  getReportRecordPreviews,
-  getIncidentLogPreviews,
+  // 타입별 detail
+  getMessageDetails,
+  getVoiceDetails,
+  getTrackingDetails,
+  getReportRecordDetails,
+  getIncidentLogDetails,
 } from '@/api/evidence';
 import type {
   EvidenceType,
   EvidencePreviewItem,
   PresignedUrlItemRequest,
-  MessagePreviewListResponse,
-  VoicePreviewListResponse,
-  TrackingPreviewListResponse,
-  ReportRecordPreviewListResponse,
-  IncidentLogPreviewListResponse,
+  MessageDetailListResponse,
+  VoiceDetailListResponse,
+  TrackingDetailListResponse,
+  ReportRecordDetailListResponse,
+  IncidentLogDetailListResponse,
 } from '@/types/evidence';
 import { EVIDENCE_CONFIG } from '../components/evidence/constants';
 import { getMediaDuration } from '../components/evidence/validate';
@@ -37,62 +37,67 @@ const evidenceKeys = {
   allPreviews: (complaintId: string) => ['evidence', 'previews', complaintId] as const,
 };
 
-// ─── 타입별 preview → 통일 PreviewItem 변환 ────────────
+// ─── 타입별 detail → 통일 PreviewItem 변환 ─────────────
 
 const fetchAndNormalize: Record<
   EvidenceType,
   (complaintId: string) => Promise<{ items: EvidencePreviewItem[]; totalCount: number }>
 > = {
   MESSAGE: async (complaintId) => {
-    const res: MessagePreviewListResponse = await getMessagePreviews(complaintId);
+    const res: MessageDetailListResponse = await getMessageDetails(complaintId);
     return {
-      items: res.previews.map((p) => ({
-        id: p.message_id,
-        thumbnailUrl: p.thumbnail_url,
+      items: res.details.map((d) => ({
+        id: d.message_id,
+        filename: d.filename,
+        thumbnailUrl: d.thumbnail_url,
+        sizeBytes: d.size_bytes,
       })),
       totalCount: res.total_count,
     };
   },
   VOICE: async (complaintId) => {
-    const res: VoicePreviewListResponse = await getVoicePreviews(complaintId);
+    const res: VoiceDetailListResponse = await getVoiceDetails(complaintId);
     return {
-      items: res.previews.map((p) => ({
-        id: p.voice_id,
-        filename: p.filename,
-        durationSeconds: p.duration_seconds,
+      items: res.details.map((d) => ({
+        id: d.voice_id,
+        filename: d.filename,
+        sizeBytes: d.size_bytes,
+        durationSeconds: d.duration_seconds,
       })),
       totalCount: res.total_count,
     };
   },
   TRACKING: async (complaintId) => {
-    const res: TrackingPreviewListResponse = await getTrackingPreviews(complaintId);
+    const res: TrackingDetailListResponse = await getTrackingDetails(complaintId);
     return {
-      items: res.previews.map((p) => ({
-        id: p.tracking_id,
-        thumbnailUrl: p.thumbnail_url,
-        durationSeconds: p.duration_seconds,
+      items: res.details.map((d) => ({
+        id: d.tracking_id,
+        filename: d.filename,
+        thumbnailUrl: d.thumbnail_url,
+        sizeBytes: d.size_bytes,
+        durationSeconds: d.duration_seconds,
       })),
       totalCount: res.total_count,
     };
   },
   REPORT_RECORD: async (complaintId) => {
-    const res: ReportRecordPreviewListResponse = await getReportRecordPreviews(complaintId);
+    const res: ReportRecordDetailListResponse = await getReportRecordDetails(complaintId);
     return {
-      items: res.previews.map((p) => ({
-        id: p.report_record_id,
-        filename: p.filename,
-        sizeBytes: p.size_bytes,
+      items: res.details.map((d) => ({
+        id: d.report_record_id,
+        filename: d.filename,
+        sizeBytes: d.size_bytes,
       })),
       totalCount: res.total_count,
     };
   },
   INCIDENT_LOG: async (complaintId) => {
-    const res: IncidentLogPreviewListResponse = await getIncidentLogPreviews(complaintId);
+    const res: IncidentLogDetailListResponse = await getIncidentLogDetails(complaintId);
     return {
-      items: res.previews.map((p) => ({
-        id: p.incident_log_id,
-        filename: p.filename,
-        sizeBytes: p.size_bytes ?? undefined,
+      items: res.details.map((d) => ({
+        id: d.incident_log_id,
+        filename: d.filename,
+        sizeBytes: d.size_bytes ?? undefined,
       })),
       totalCount: res.total_count,
     };

--- a/src/app/my-space/case/hooks/useEvidence.ts
+++ b/src/app/my-space/case/hooks/useEvidence.ts
@@ -16,8 +16,18 @@ import {
   getReportRecordPreviews,
   getIncidentLogPreviews,
 } from '@/api/evidence';
-import type { EvidenceType, PresignedUrlItemRequest } from '@/types/evidence';
+import type {
+  EvidenceType,
+  EvidencePreviewItem,
+  PresignedUrlItemRequest,
+  MessagePreviewListResponse,
+  VoicePreviewListResponse,
+  TrackingPreviewListResponse,
+  ReportRecordPreviewListResponse,
+  IncidentLogPreviewListResponse,
+} from '@/types/evidence';
 import { EVIDENCE_CONFIG } from '../components/evidence/constants';
+import { getMediaDuration } from '../components/evidence/validate';
 
 // ─── query key ──────────────────────────────────────────
 
@@ -27,17 +37,66 @@ const evidenceKeys = {
   allPreviews: (complaintId: string) => ['evidence', 'previews', complaintId] as const,
 };
 
-// ─── 타입별 preview 조회 함수 매핑 ─────────────────────
+// ─── 타입별 preview → 통일 PreviewItem 변환 ────────────
 
-const previewFetchers: Record<
+const fetchAndNormalize: Record<
   EvidenceType,
-  (complaintId: string, limit?: number) => Promise<{ total_count: number }>
+  (complaintId: string) => Promise<{ items: EvidencePreviewItem[]; totalCount: number }>
 > = {
-  MESSAGE: getMessagePreviews,
-  VOICE: getVoicePreviews,
-  TRACKING: getTrackingPreviews,
-  REPORT_RECORD: getReportRecordPreviews,
-  INCIDENT_LOG: getIncidentLogPreviews,
+  MESSAGE: async (complaintId) => {
+    const res: MessagePreviewListResponse = await getMessagePreviews(complaintId);
+    return {
+      items: res.previews.map((p) => ({
+        id: p.message_id,
+        thumbnailUrl: p.thumbnail_url,
+      })),
+      totalCount: res.total_count,
+    };
+  },
+  VOICE: async (complaintId) => {
+    const res: VoicePreviewListResponse = await getVoicePreviews(complaintId);
+    return {
+      items: res.previews.map((p) => ({
+        id: p.voice_id,
+        filename: p.filename,
+        durationSeconds: p.duration_seconds,
+      })),
+      totalCount: res.total_count,
+    };
+  },
+  TRACKING: async (complaintId) => {
+    const res: TrackingPreviewListResponse = await getTrackingPreviews(complaintId);
+    return {
+      items: res.previews.map((p) => ({
+        id: p.tracking_id,
+        thumbnailUrl: p.thumbnail_url,
+        durationSeconds: p.duration_seconds,
+      })),
+      totalCount: res.total_count,
+    };
+  },
+  REPORT_RECORD: async (complaintId) => {
+    const res: ReportRecordPreviewListResponse = await getReportRecordPreviews(complaintId);
+    return {
+      items: res.previews.map((p) => ({
+        id: p.report_record_id,
+        filename: p.filename,
+        sizeBytes: p.size_bytes,
+      })),
+      totalCount: res.total_count,
+    };
+  },
+  INCIDENT_LOG: async (complaintId) => {
+    const res: IncidentLogPreviewListResponse = await getIncidentLogPreviews(complaintId);
+    return {
+      items: res.previews.map((p) => ({
+        id: p.incident_log_id,
+        filename: p.filename,
+        sizeBytes: p.size_bytes ?? undefined,
+      })),
+      totalCount: res.total_count,
+    };
+  },
 };
 
 // ─── 타입별 register 함수 매핑 ──────────────────────────
@@ -76,8 +135,9 @@ const registerByType = async (
 export function useEvidencePreviews(complaintId: string | undefined, type: EvidenceType) {
   return useQuery({
     queryKey: evidenceKeys.previews(complaintId!, type),
-    queryFn: () => previewFetchers[type](complaintId!),
+    queryFn: () => fetchAndNormalize[type](complaintId!),
     enabled: !!complaintId,
+    staleTime: 1000 * 60 * 5, // 5분간 캐시 유지 (불필요한 refetch 방지)
   });
 }
 
@@ -90,12 +150,18 @@ export function useUploadEvidence(complaintId: string | undefined, type: Evidenc
   return useMutation({
     mutationFn: async (files: File[]) => {
       // 1) presigned URL 발급
+      // VOICE/TRACKING은 실제 재생 길이를 구해서 전달
+      let durations: number[] = [];
+      if (config.maxDuration) {
+        durations = await Promise.all(files.map((f) => getMediaDuration(f)));
+      }
+
       const presignedItems: PresignedUrlItemRequest[] = files.map((file, i) => ({
         index: i,
         filename: file.name,
         contentType: file.type,
         sizeBytes: file.size,
-        ...(config.maxDuration ? { durationSeconds: 0 } : {}), // TODO: 실제 duration 전달
+        ...(config.maxDuration ? { durationSeconds: Math.round(durations[i]) } : {}),
       }));
 
       const { items: presignedUrls } = await getPresignedUrls(complaintId!, {

--- a/src/app/my-space/case/hooks/useEvidenceCard.ts
+++ b/src/app/my-space/case/hooks/useEvidenceCard.ts
@@ -1,0 +1,84 @@
+import { useRef, useState } from 'react';
+import { EVIDENCE_CONFIG } from '../components/evidence/constants';
+import { filterValidFiles } from '../components/evidence/validate';
+import { useEvidencePreviews, useUploadEvidence, useDeleteEvidence } from './useEvidence';
+import type { EvidenceType } from '@/types/evidence';
+
+/**
+ * 증거 카드 로직 훅
+ *
+ * - React Query 호출 및 상태 관리
+ * - 파일 업로드/삭제 핸들러
+ * - 삭제 확인 모달 상태
+ */
+export function useEvidenceCard(complaintId: string | undefined, type: EvidenceType) {
+  const config = EVIDENCE_CONFIG[type];
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // 삭제 확인 모달 상태
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+
+  // React Query 훅
+  const { data } = useEvidencePreviews(complaintId, type);
+  const upload = useUploadEvidence(complaintId, type);
+  const remove = useDeleteEvidence(complaintId, type);
+
+  const items = data?.items ?? [];
+  const totalCount = data?.totalCount ?? 0;
+  const isFull = totalCount >= config.maxFiles;
+
+  /** 파일 추가 — 프론트 검증 후 업로드 mutation 호출 */
+  const handleFilesAdd = async (newFiles: File[]) => {
+    if (isFull) return; // 개수 초과 시 업로드 차단
+    const valid = await filterValidFiles(newFiles, config, totalCount);
+    if (valid.length > 0) upload.mutate(valid);
+  };
+
+  /** 증거 삭제 - 모달 열기 */
+  const handleRemove = (id: string) => {
+    setDeleteTargetId(id);
+    setDeleteModalOpen(true);
+  };
+
+  /** 삭제 확인 */
+  const confirmDelete = () => {
+    if (deleteTargetId) {
+      remove.mutate([deleteTargetId]);
+    }
+    setDeleteModalOpen(false);
+    setDeleteTargetId(null);
+  };
+
+  /** 삭제 취소 */
+  const cancelDelete = () => {
+    setDeleteModalOpen(false);
+    setDeleteTargetId(null);
+  };
+
+  /** hidden input 트리거 */
+  const openFilePicker = () => inputRef.current?.click();
+
+  return {
+    // Refs
+    inputRef,
+
+    // 상태
+    config,
+    items,
+    totalCount,
+    isFull,
+    isUploading: upload.isPending,
+
+    // 모달 상태
+    deleteModalOpen,
+    setDeleteModalOpen,
+
+    // 핸들러
+    handleFilesAdd,
+    handleRemove,
+    confirmDelete,
+    cancelDelete,
+    openFilePicker,
+  };
+}

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -79,7 +79,7 @@ export default function CasePage() {
         {/* 4단계 프로그레스 바 */}
         <CaseProgress currentStep={step} />
         {/* 스텝별 컨텐츠 조건부 렌더링 */}
-        {step === 1 && <StepCollect />}
+        {step === 1 && <StepCollect complaintId={user?.complaint_id} />}
         {step === 2 && <StepTimeline />}
         {step === 3 && <StepDocument />}
         {step === 4 && <StepComplete />}

--- a/src/types/evidence.ts
+++ b/src/types/evidence.ts
@@ -373,6 +373,17 @@ export type IncidentLogFileOriginal = {
   updated_at: string;
 };
 
+// ─── 통일 프리뷰 아이템 (EvidenceContent용) ────────────
+
+/** 타입별 서버 프리뷰 데이터를 통일한 형태 */
+export type EvidencePreviewItem = {
+  id: string;
+  filename?: string;
+  thumbnailUrl?: string;
+  sizeBytes?: number;
+  durationSeconds?: number;
+};
+
 // ─── 에러 응답 ──────────────────────────────────────────
 
 export type EvidencePresignedValidationError = {

--- a/src/types/evidence.ts
+++ b/src/types/evidence.ts
@@ -1,0 +1,396 @@
+// ─── 공통 ───────────────────────────────────────────────
+
+export type EvidenceType = 'MESSAGE' | 'VOICE' | 'TRACKING' | 'REPORT_RECORD' | 'INCIDENT_LOG';
+
+// ─── Presigned URL (모든 타입 공통) ─────────────────────
+
+export type PresignedUrlItemRequest = {
+  index: number;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  durationSeconds?: number; // VOICE, TRACKING만 사용
+};
+
+export type PresignedUrlItemResponse = {
+  index: number;
+  filename: string;
+  url: string;
+  evidence_id: string; // 타입별 ID (message_id, voice_id 등)
+};
+
+export type EvidencePresignedUrlRequest = {
+  type: EvidenceType;
+  items: PresignedUrlItemRequest[];
+};
+
+export type EvidencePresignedUrlResponse = {
+  items: PresignedUrlItemResponse[];
+};
+
+// ─── 삭제 (공통) ────────────────────────────────────────
+
+export type DeleteEvidenceRequest = {
+  type: EvidenceType;
+  evidenceIds: string[];
+};
+
+// ─── 파일명 수정 (공통) ─────────────────────────────────
+
+export type UpdateEvidenceFilenameRequest = {
+  type: EvidenceType;
+  filename: string;
+};
+
+export type UpdateEvidenceFilenameResponse = {
+  evidence_id: string;
+  filename: string;
+  updated_at: string;
+};
+
+// ─── MESSAGE ────────────────────────────────────────────
+
+export type MessageRegisterItem = {
+  messageId: string;
+  filename: string;
+};
+
+export type MessageRegisterRequest = {
+  items: MessageRegisterItem[];
+};
+
+export type MessageRegisterItemResponse = {
+  message_id: string;
+  filename: string;
+  content_type: string;
+  width?: number;
+  height?: number;
+  size_bytes: number;
+};
+
+export type MessageRegisterListResponse = {
+  items: MessageRegisterItemResponse[];
+};
+
+export type MessagePreview = {
+  message_id: string;
+  thumbnail_url: string;
+};
+
+export type MessagePreviewListResponse = {
+  previews: MessagePreview[];
+  total_count: number;
+};
+
+export type MessageDetail = {
+  message_id: string;
+  filename: string;
+  size_bytes: number;
+  created_at: string;
+  updated_at: string;
+  thumbnail_url: string;
+};
+
+export type MessageDetailListResponse = {
+  details: MessageDetail[];
+  total_count: number;
+};
+
+export type MessageOriginal = {
+  message_id: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  width?: number;
+  height?: number;
+  url: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// ─── VOICE ──────────────────────────────────────────────
+
+export type VoiceRegisterItem = {
+  voiceId: string;
+  filename: string;
+};
+
+export type VoiceRegisterRequest = {
+  items: VoiceRegisterItem[];
+};
+
+export type VoiceRegisterItemResponse = {
+  voice_id: string;
+  filename: string;
+  content_type: string;
+  duration_seconds: number;
+  size_bytes: number;
+};
+
+export type VoiceRegisterListResponse = {
+  items: VoiceRegisterItemResponse[];
+};
+
+export type VoicePreview = {
+  voice_id: string;
+  filename: string;
+  duration_seconds: number;
+};
+
+export type VoicePreviewListResponse = {
+  previews: VoicePreview[];
+  total_count: number;
+};
+
+export type VoiceDetail = {
+  voice_id: string;
+  filename: string;
+  duration_seconds: number;
+  size_bytes: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type VoiceDetailListResponse = {
+  details: VoiceDetail[];
+  total_count: number;
+};
+
+export type VoiceOriginal = {
+  voice_id: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  duration_seconds: number;
+  url: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// ─── TRACKING ───────────────────────────────────────────
+
+export type TrackingRegisterItem = {
+  trackingId: string;
+  filename: string;
+};
+
+export type TrackingRegisterRequest = {
+  items: TrackingRegisterItem[];
+};
+
+export type TrackingRegisterItemResponse = {
+  tracking_id: string;
+  filename: string;
+  content_type: string;
+  duration_seconds: number;
+  size_bytes: number;
+};
+
+export type TrackingRegisterListResponse = {
+  items: TrackingRegisterItemResponse[];
+};
+
+export type TrackingPreview = {
+  tracking_id: string;
+  duration_seconds: number;
+  thumbnail_url: string;
+};
+
+export type TrackingPreviewListResponse = {
+  previews: TrackingPreview[];
+  total_count: number;
+};
+
+export type TrackingDetail = {
+  tracking_id: string;
+  filename: string;
+  duration_seconds: number;
+  size_bytes: number;
+  created_at: string;
+  updated_at: string;
+  thumbnail_url: string;
+};
+
+export type TrackingDetailListResponse = {
+  details: TrackingDetail[];
+  total_count: number;
+};
+
+export type TrackingOriginal = {
+  tracking_id: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  duration_seconds: number;
+  url: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// ─── REPORT_RECORD ──────────────────────────────────────
+
+export type ReportRecordRegisterItem = {
+  reportRecordId: string;
+  filename: string;
+};
+
+export type ReportRecordRegisterRequest = {
+  items: ReportRecordRegisterItem[];
+};
+
+export type ReportRecordRegisterItemResponse = {
+  report_record_id: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+};
+
+export type ReportRecordRegisterListResponse = {
+  items: ReportRecordRegisterItemResponse[];
+};
+
+export type ReportRecordPreview = {
+  report_record_id: string;
+  filename: string;
+  size_bytes: number;
+};
+
+export type ReportRecordPreviewListResponse = {
+  previews: ReportRecordPreview[];
+  total_count: number;
+};
+
+export type ReportRecordDetail = {
+  report_record_id: string;
+  filename: string;
+  size_bytes: number;
+  content_type: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ReportRecordDetailListResponse = {
+  details: ReportRecordDetail[];
+  total_count: number;
+};
+
+export type ReportRecordOriginal = {
+  report_record_id: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  url: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// ─── INCIDENT_LOG ───────────────────────────────────────
+
+export type IncidentLogType = 'FILE' | 'FORM_DATA';
+
+/** 파일 업로드 방식 등록 */
+export type IncidentLogFileRegisterItem = {
+  incidentLogId: string;
+  filename: string;
+};
+
+export type IncidentLogFileRegisterRequest = {
+  items: IncidentLogFileRegisterItem[];
+};
+
+export type IncidentLogFileRegisterItemResponse = {
+  incident_log_id: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+};
+
+export type IncidentLogFileRegisterListResponse = {
+  items: IncidentLogFileRegisterItemResponse[];
+};
+
+/** 폼 데이터 방식 */
+export type IncidentLogFormDataUploadRequest = {
+  filename: string;
+  date: string; // YYYY-MM-DD
+  time: string; // HH:MM
+  location: string;
+  description: string;
+  witness: string;
+  perceivedRisk: string; // 매우 높음 | 높음 | 보통 | 낮음 | 매우 낮음
+};
+
+export type IncidentLogFormDataUpdateRequest = Partial<IncidentLogFormDataUploadRequest>;
+
+export type IncidentLogFormDataResponse = {
+  incident_log_id: string;
+  filename: string;
+  date: string;
+  time: string;
+  location: string;
+  description: string;
+  witness: string;
+  perceived_risk: string;
+  created_at: string;
+  updated_at: string;
+};
+
+/** 프리뷰 / 상세 (FILE + FORM_DATA 혼합) */
+export type IncidentLogPreview = {
+  incident_log_id: string;
+  type: IncidentLogType;
+  filename: string;
+  size_bytes?: number | null; // 폼데이터면 null
+};
+
+export type IncidentLogPreviewListResponse = {
+  previews: IncidentLogPreview[];
+  total_count: number;
+};
+
+export type IncidentLogDetail = {
+  incident_log_id: string;
+  type: IncidentLogType;
+  filename: string;
+  size_bytes?: number | null;
+  content_type?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type IncidentLogDetailListResponse = {
+  details: IncidentLogDetail[];
+  total_count: number;
+};
+
+export type IncidentLogFileOriginal = {
+  incident_log_id: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  url: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// ─── 에러 응답 ──────────────────────────────────────────
+
+export type EvidencePresignedValidationError = {
+  code: 'EVIDENCE_PRESIGNED_VALIDATION_FAILED';
+  message: string;
+  debug_message?: string;
+  is_total_count_valid: boolean;
+  content_type_failed_index_list: number[];
+  size_bytes_failed_index_list: number[];
+  duration_seconds_failed_index_list?: number[];
+};
+
+export type RegisterEvidenceError = {
+  code: string;
+  message: string;
+  debug_message?: string;
+  failed_evidence_ids?: string[];
+  content_type_failed_evidence_ids?: string[];
+  size_bytes_failed_evidence_ids?: string[];
+  duration_seconds_failed_evidence_ids?: string[];
+};

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,24 @@
+/**
+ * 파일 크기를 KB/MB 단위로 포맷팅
+ *
+ * @param bytes - 파일 크기 (바이트)
+ * @returns "1.2KB", "3.5MB" 형식 문자열
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+/**
+ * 재생 시간을 MM:SS 형식으로 포맷팅
+ *
+ * @param seconds - 재생 시간 (초)
+ * @returns "01:23" 형식 문자열
+ */
+export function formatDuration(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+}


### PR DESCRIPTION
# 작업 내용

Step 1(증거 수집) 페이지의 **증거 파일 업로드 전체 파이프라인**을 구현했습니다.

> 프론트 사전 검증 → Presigned URL 발급 → S3 직접 업로드 → 서버 등록 → 프리뷰 조회/삭제
> 전체 흐름이 정상 동작합니다.

---

## 1. 파일 사전 검증 로직

`validate.ts`, `constants.ts`

`<input accept>`는 드래그앤드롭 시 우회 가능하므로,
**JS 레벨에서 재검증 로직을 추가**했습니다.

### 타입별 제한 정책

| 타입            | 허용 형식               | 최대 크기 | 최대 개수 | 최대 길이 |
| ------------- | ------------------- | ----- | ----- | ----- |
| MESSAGE       | jpg, png, heic      | 10MB  | 10개   | —     |
| VOICE         | m4a, mp3, wav       | 20MB  | 5개    | 5분    |
| TRACKING      | mp4, mov            | 500MB | 3개    | 5분    |
| REPORT_RECORD | pdf, hwp, docx, txt | 10MB  | 3개    | —     |
| INCIDENT_LOG  | pdf, hwp, docx, txt | 10MB  | 3개    | —     |

### 검증 순서

1. MIME / 확장자
2. 파일 크기
3. 영상/음성 길이
4. 남은 개수

* `.hwp` 등 MIME이 비어 있는 경우 확장자로 폴백
* 길이 검증은 `video.preload = 'metadata'` 사용 (파일 전체 로드 방지)

---

## 2. 타입 정의 정리

`types/evidence.ts`

Swagger 스펙 기반으로 5개 증거 타입의 요청/응답 타입 정의.

### 공통 타입

* `PresignedUrlItemRequest/Response`
* `DeleteEvidenceRequest`
* `UpdateEvidenceFilenameRequest`

### 타입별 Register/Preview 응답

각 타입마다 ID 필드명이 다르므로 명확히 분리:

* `messageId`
* `voiceId`
* `trackingId`
* `reportRecordId`
* `incidentLogId`

### Preview 정규화

타입별 응답 구조가 달라
프론트 내부에서는 `EvidencePreviewItem`으로 정규화:

```ts
{
  id: string
  filename?: string
  thumbnailUrl?: string
  sizeBytes?: number
  durationSeconds?: number
}
```

→ UI는 타입 차이를 인지하지 않도록 설계

---

## 3. 업로드 파이프라인

1. `getMessagePresignedUrl()`
2. `uploadToS3(presigned_url, file)`
3. `registerMessageEvidence({ s3_keys, ... })`

### 설계 의도

* 서버를 거치지 않고 **S3 직접 업로드**
* 서버 부하 감소
* 500MB 대용량 파일 안정적 처리

### 프리뷰 / 삭제

* 프리뷰: 타입별 API → `EvidencePreviewItem[]` 정규화
* 삭제: 단일/다중 삭제 지원

---

## 4. React Query 구조

### `useEvidence.ts` (서버 상태)

* `useEvidencePreviews`

  * `staleTime: 30초`
  * 응답 정규화 처리
* `useUploadEvidence`

  * presigned → S3 → register 순차 실행
  * 성공 시 목록 자동 refetch
* `useDeleteEvidence`

  * 삭제 후 자동 refetch

### `useEvidenceCard.ts` (UI 로직 분리)

EvidenceCard의 상태/핸들러 분리
(133줄 → 90줄)

* 삭제 모달 상태
* 업로드 핸들러
* `isFull` 계산
* 추후 각 로직 세분화 예정 (필요시)

---

## 5. 컴포넌트 구조 개선

### Before

```ts
useState<File[]>
```

→ 로컬 상태 관리

### After

React Query 기반 서버 상태를 단일 진실 공급원으로 사용

* complaintId 전달 구조 정리
* 서버 프리뷰 기반 렌더링
* 업로드/삭제 후 자동 동기화

---

## 6. UI/UX 개선 사항

### 업로드 제한 명확화

* `isFull` 상태로 버튼 비활성화

### 삭제 확인 모달

* “삭제된 증거는 되돌릴 수 없어요” 경고
* 실수 방지 UX

### 포맷 유틸

* `formatFileSize`
* `formatDuration`

### ImagePreview 리팩토링

* 중복 제거 (13줄 → 5줄)

### Next.js 이미지 설정

* S3 도메인 `remotePatterns` 추가
* `unoptimized: true`로 경고 해결

---
## 참고사항

* 프론트 단에서 프리뷰 이미지 생성은 하지 않음 ( 업로드 로직이 그렇게 느리지 않음, 추후 낙관적 업데이트나 필요하다 생각들면 추가할 예정)

---

## 이슈

close #33 

---
## 스크린샷
* 업로드 상태 / 삭제 모
<img width="2228" height="1753" alt="image" src="https://github.com/user-attachments/assets/ee6f97ba-a963-4131-9080-87a41ec0babe" />
<img width="2228" height="1753" alt="image" src="https://github.com/user-attachments/assets/2d3481ea-39e5-4cf8-965d-7b1e986aa47d" />

* 검증
<img width="951" height="432" alt="스크린샷 2026-02-26 185935" src="https://github.com/user-attachments/assets/c6a9b184-2202-4914-97a7-b6d5ba232903" />
<img width="904" height="161" alt="스크린샷 2026-02-26 190210" src="https://github.com/user-attachments/assets/2634714c-403d-4e32-b24e-fba6377f38cc" />

* 업로드
<img width="1386" height="148" alt="image" src="https://github.com/user-attachments/assets/db90ca02-3e8f-428f-a64d-81201f3e3443" />





