### PR TITLE
[FIX][#41]: QA 이슈 수정 - 인증 UX 및 Step 1 증거 수집 UX 개선

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -42,6 +42,11 @@ axiosInstance.interceptors.response.use(
 
     // 401 에러이고, 재시도하지 않은 요청인 경우
     if (error.response?.status === 401 && !originalRequest._retry) {
+      // 로그인 API에서 발생한 401은 인증 실패 에러이므로 갱신 시도 없이 그대로 처리
+      if (originalRequest.url?.includes('/users/login/')) {
+        return Promise.reject(error.response?.data ?? error);
+      }
+
       // 토큰 갱신 API 자체에서 401이 발생한 경우 → 로그인 페이지로
       if (originalRequest.url?.includes('/token/refresh')) {
         authCookies.clearTokens();

--- a/src/app/auth/components/LoginForm.tsx
+++ b/src/app/auth/components/LoginForm.tsx
@@ -50,13 +50,6 @@ export function LoginForm() {
           onIconClick={togglePassword}
           {...form.register('password')}
         />
-
-        {/* 전체 에러 메시지 (root 에러) */}
-        {form.formState.errors.root && (
-          <p className="text-error text-[12px] leading-4.5 font-medium">
-            {form.formState.errors.root.message}
-          </p>
-        )}
       </div>
 
       <div className="space-y-3">

--- a/src/app/auth/hooks/useEmailVerifyForm.ts
+++ b/src/app/auth/hooks/useEmailVerifyForm.ts
@@ -7,6 +7,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { VerifyEmailFormValues, verifyEmailSchema } from '@/schemas/auth/verify-email.schema';
 import { verifyEmail, resendVerificationEmail } from '@/api/auth/signup';
 import type { ApiError } from '@/types/api';
+import { showAlert } from '@/utils/alert';
 
 export function useEmailVerifyForm(email: string) {
   const router = useRouter();
@@ -28,10 +29,12 @@ export function useEmailVerifyForm(email: string) {
     setIsResending(true);
     try {
       await resendVerificationEmail(email);
-      // TODO: 성공 토스트 메시지
-    } catch (err) {
-      console.error('이메일 재전송 실패:', err);
-      // TODO: 실패 토스트 메시지
+      showAlert.success({
+        title: '인증 메일 재전송 완료',
+        description: '메일로 인증번호를 다시 전송드렸습니다',
+      });
+    } catch {
+      showAlert.error({ title: '인증 메일 재전송에 실패했습니다' });
     } finally {
       setIsResending(false);
     }

--- a/src/app/auth/hooks/useLoginForm.ts
+++ b/src/app/auth/hooks/useLoginForm.ts
@@ -8,6 +8,7 @@ import { loginSchema, type LoginFormValues } from '@/schemas/auth/login.schema';
 import { loginEmail } from '@/api/auth/login';
 import type { ApiError } from '@/types/api';
 import { useAuthStore } from '@/stores/authStore';
+import { showAlert } from '@/utils/alert';
 
 export function useLoginForm() {
   const router = useRouter();
@@ -41,15 +42,26 @@ export function useLoginForm() {
       const data = err as ApiError;
 
       if (data?.code === 'USER_NOT_FOUND') {
-        form.setError('email', { message: data.message });
+        showAlert.error({
+          title: '가입된 계정을 찾을 수 없습니다',
+          description:
+            '입력하신 이메일로 가입된 계정이 없습니다.\n이메일 주소를 다시 확인하시거나 회원가입을 진행해 주세요.',
+        });
       } else if (data?.code === 'INVALID_CREDENTIALS') {
         sessionStorage.setItem('loginEmail', values.email);
-        form.setError('password', { message: data.message });
+        showAlert.error({
+          title: '로그인 정보를 확인해 주세요',
+          description: '이메일 또는 비밀번호가 올바르지 않습니다.\n입력 내용을 다시 확인해 주세요.',
+        });
       } else if (data?.code === 'USER_NOT_CONFIRMED') {
         sessionStorage.setItem('loginEmail', values.email);
-        form.setError('root', { message: data.message });
+        showAlert.error({
+          title: '이메일 인증이 필요합니다',
+          description:
+            '아직 이메일 인증이 완료되지 않았습니다.\n이메일을 확인하신 후 인증을 완료해 주세요.',
+        });
       } else {
-        form.setError('root', { message: data?.message ?? '로그인에 실패했습니다' });
+        showAlert.error({ title: '로그인에 실패했습니다' });
       }
     }
   };

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -5,7 +5,7 @@ import { SignupForm } from '../components/SignupForm';
 /** 이메일 회원가입 페이지 */
 export default function SignupPage() {
   return (
-    <div className="pb-24">
+    <div>
       {/* 제목 */}
       <div className="mb-8">
         <h1 className="typo-display-2 mb-2 text-black">회원가입</h1>

--- a/src/app/my-space/case/components/CaseHeader.tsx
+++ b/src/app/my-space/case/components/CaseHeader.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 import { Button } from '@/components/Button';
 import { Input } from '@/components/Input';
 import EditOutlineIcon from '@/assets/icons/EditOutlineIcon.svg';
+import { formatDateKo } from '@/utils/date';
 
 interface CaseHeaderProps {
   /** 사건 제목 */
@@ -101,7 +102,7 @@ export function CaseHeader({
             <EditOutlineIcon className="aria-hidden size-5 text-gray-400" />
           </button>
         )}
-        <span className="typo-body-8 text-gray-400">최종 수정일: {updatedAt}</span>
+        <span className="typo-body-8 text-gray-400">최종 수정일: {formatDateKo(updatedAt)}</span>
       </div>
       <div className="flex items-center gap-2">
         <Button color="secondary" size="lg" onClick={onSave} loading={isSaving}>

--- a/src/app/my-space/case/components/CaseHeader.tsx
+++ b/src/app/my-space/case/components/CaseHeader.tsx
@@ -2,7 +2,6 @@
 
 import { useRef, useState } from 'react';
 import { Button } from '@/components/Button';
-import { Input } from '@/components/Input';
 import EditOutlineIcon from '@/assets/icons/EditOutlineIcon.svg';
 import { formatDateKo } from '@/utils/date';
 
@@ -58,9 +57,9 @@ export function CaseHeader({
   /** 편집 확정 */
   const confirmEdit = () => {
     const trimmedTitle = draft.trim();
-    if (trimmedTitle) {
+    if (trimmedTitle && trimmedTitle !== title) {
       onTitleChange(trimmedTitle);
-    } else {
+    } else if (!trimmedTitle) {
       setDraft(title); // 빈 제목은 허용하지 않고 원래 제목으로 복구
     }
     setIsEditing(false);
@@ -83,13 +82,13 @@ export function CaseHeader({
       <div className="flex flex-col gap-1">
         {/* 제목 표시 / 편집 */}
         {isEditing ? (
-          <Input
+          <input
             ref={inputRef}
             value={draft}
-            onChange={(e) => setDraft(e.target.value)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setDraft(e.target.value)}
             onBlur={confirmEdit}
             onKeyDown={handleKeyDown}
-            size="sm"
+            className="typo-heading-2 w-60 border-b border-gray-300 bg-transparent py-0 text-gray-900 outline-none focus:border-gray-500"
           />
         ) : (
           <button

--- a/src/app/my-space/case/components/evidence/EvidenceCard.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceCard.tsx
@@ -91,7 +91,12 @@ export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps
               </span>
             </Button>
           )}
-          <Button color="secondary" size="lg" onClick={openFilePicker} disabled={isFull}>
+          <Button
+            color="secondary"
+            size="lg"
+            onClick={openFilePicker}
+            disabled={isFull || isUploading}
+          >
             <span className="flex items-center gap-2">
               <UploadIcon className="h-4 w-4" />
               증거 업로드

--- a/src/app/my-space/case/components/evidence/EvidenceContent.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceContent.tsx
@@ -42,19 +42,19 @@ export function EvidenceContent({
 }: EvidenceContentProps) {
   /** 드래그 오버 상태 — true면 테두리/배경 강조 */
   const [isDragOver, setIsDragOver] = useState(false);
+  const canUpload = !isUploading;
 
   /** 드롭 시 파일 처리 + 드래그 상태 해제 */
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragOver(false);
-    const droppedFiles = Array.from(e.dataTransfer.files);
-    if (droppedFiles.length > 0) onFilesAdd(droppedFiles);
+    if (canUpload && e.dataTransfer.files.length > 0) onFilesAdd(Array.from(e.dataTransfer.files));
   };
 
   /** 드래그 오버 시 기본 동작 방지 + 강조 표시 */
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
-    setIsDragOver(true);
+    setIsDragOver(canUpload);
   };
 
   /** 드래그 영역 벗어나면 강조 해제 */
@@ -72,10 +72,10 @@ export function EvidenceContent({
           onDrop={handleDrop}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
-          onClick={onClickUpload}
-          className={`bg-bg-2 flex h-full cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-[1.5px] border-dashed px-6 py-9 transition ${
-            isDragOver ? 'border-primary bg-primary/5' : 'border-gray-200'
-          }`}
+          onClick={canUpload ? onClickUpload : undefined}
+          className={`bg-bg-2 flex h-full flex-col items-center justify-center gap-2 rounded-lg border-[1.5px] border-dashed px-6 py-9 transition ${
+            canUpload ? 'cursor-pointer' : 'cursor-default'
+          } ${isDragOver ? 'border-primary bg-primary/5' : 'border-gray-200'}`}
         >
           {isUploading ? (
             <Spinner size="lg" className="text-gray-400" label="파일 업로드 중" />

--- a/src/app/my-space/case/components/evidence/IncidentLogFormModal.tsx
+++ b/src/app/my-space/case/components/evidence/IncidentLogFormModal.tsx
@@ -12,6 +12,7 @@ import { useUploadIncidentLogFormData, useUploadEvidence } from '../../hooks/use
 import { filterValidFiles } from './validate';
 import { EVIDENCE_CONFIG } from './constants';
 import { FilePreview } from './FilePreview';
+import { getTodayString } from '@/utils/date';
 
 const incidentLogSchema = z.object({
   filename: z.string().min(1, '제목을 입력해주세요'),
@@ -27,10 +28,6 @@ interface IncidentLogFormModalProps {
   open: boolean;
   onClose: () => void;
   complaintId: string | undefined;
-}
-
-function getTodayString() {
-  return new Date().toISOString().split('T')[0];
 }
 
 const config = EVIDENCE_CONFIG.INCIDENT_LOG;

--- a/src/app/my-space/case/components/evidence/IncidentLogFormModal.tsx
+++ b/src/app/my-space/case/components/evidence/IncidentLogFormModal.tsx
@@ -8,8 +8,7 @@ import UploadIcon from '@/assets/icons/UploadIcon.svg';
 import { Button } from '@/components/Button';
 import { Input } from '@/components/Input';
 import { Modal } from '@/components/modals/Modal';
-import { useUploadIncidentLogFormData, useUploadEvidence } from '../../hooks/useEvidence';
-import { filterValidFiles } from './validate';
+import { useUploadIncidentLogFormData } from '../../hooks/useEvidence';
 import { EVIDENCE_CONFIG } from './constants';
 import { FilePreview } from './FilePreview';
 import { getTodayString } from '@/utils/date';
@@ -42,6 +41,7 @@ export function IncidentLogFormModal({ open, onClose, complaintId }: IncidentLog
     register,
     handleSubmit,
     control,
+    reset,
     formState: { errors, isValid },
   } = useForm<IncidentLogFormValues>({
     resolver: zodResolver(incidentLogSchema),
@@ -58,25 +58,19 @@ export function IncidentLogFormModal({ open, onClose, complaintId }: IncidentLog
   const descriptionLength = useWatch({ control, name: 'description' }).length;
 
   const uploadFormData = useUploadIncidentLogFormData(complaintId);
-  const uploadFiles = useUploadEvidence(complaintId, 'INCIDENT_LOG');
 
-  const handleFilesAdd = async (files: File[]) => {
-    const { valid } = await filterValidFiles(files, config, localFiles.length);
-    if (valid.length > 0) setLocalFiles((prev) => [...prev, ...valid]);
+  const handleFilesAdd = (files: File[]) => {
+    setLocalFiles((prev) => [...prev, ...files]);
   };
 
   const onSubmit = async (values: IncidentLogFormValues) => {
-    const tasks: Promise<unknown>[] = [
-      uploadFormData.mutateAsync({ ...values, witness: '', perceivedRisk: '' }),
-    ];
-    if (localFiles.length > 0) {
-      tasks.push(uploadFiles.mutateAsync(localFiles));
-    }
-    await Promise.all(tasks);
+    await uploadFormData.mutateAsync({ ...values, witness: '', perceivedRisk: '' });
+    reset();
+    setLocalFiles([]);
     onClose();
   };
 
-  const isPending = uploadFormData.isPending || uploadFiles.isPending;
+  const isPending = uploadFormData.isPending;
 
   return (
     <Modal.Root

--- a/src/app/styles/base.css
+++ b/src/app/styles/base.css
@@ -42,13 +42,11 @@
   }
 }
 
-@layer scrollbar {
-  .no-scrollbar::-webkit-scrollbar {
-    display: none;
-  }
-  .no-scrollbar {
-    scrollbar-width: none;
-  }
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+.no-scrollbar {
+  scrollbar-width: none;
 }
 
 * {

--- a/src/components/ActionInput.tsx
+++ b/src/components/ActionInput.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Input, InputProps } from './Input';
 import { Button } from './Button';
+import { Spinner } from './Spinner';
 import { cn } from '@/lib/utils';
 
 type ButtonVariant = 'default' | 'outline' | 'ghost';
@@ -57,7 +58,7 @@ export const ActionInput = React.forwardRef<HTMLInputElement, ActionInputProps>(
           disabled={buttonDisabled || buttonLoading}
           className={cn('h-12 w-22.5 shrink-0', inputProps.label && 'mt-6')}
         >
-          {buttonLoading ? '처리중...' : buttonLabel}
+          {buttonLoading ? <Spinner size="sm" /> : buttonLabel}
         </Button>
       </div>
     );

--- a/src/components/AlertCard.tsx
+++ b/src/components/AlertCard.tsx
@@ -26,7 +26,9 @@ export function AlertCard({ variant, title, description, onClose }: AlertCardPro
       <Image src={icon} alt="" width={24} height={24} className="shrink-0" />
       <div className="flex-1 space-y-0.5">
         <p className="typo-heading-4 text-gray-900">{title}</p>
-        {description && <p className="typo-body-7 text-gray-500">{description}</p>}
+        {description && (
+          <p className="typo-body-7 whitespace-pre-line text-gray-500">{description}</p>
+        )}
       </div>
       {onClose && (
         <button

--- a/src/components/MySpaceSidebar.tsx
+++ b/src/components/MySpaceSidebar.tsx
@@ -78,12 +78,16 @@ export function MySpaceSidebar() {
                 const isActive = pathname === item.href;
 
                 return (
-                  <SidebarMenuItem key={item.href}>
+                  <SidebarMenuItem
+                    key={item.href}
+                    className="group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center"
+                  >
                     <SidebarMenuButton
                       asChild
                       isActive={isActive}
+                      size="lg"
                       tooltip={item.label}
-                      className="typo-heading-5 h-12 p-0 text-gray-300 group-data-[collapsible=icon]:size-12! data-[active=true]:font-semibold data-[active=true]:text-gray-800"
+                      className="typo-heading-5 text-gray-300 group-data-[collapsible=icon]:size-12! data-[active=true]:font-semibold data-[active=true]:text-gray-800"
                     >
                       <Link href={item.href}>
                         <span className="relative size-12 shrink-0">

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,24 @@
 /**
+ * ISO 날짜 문자열을 한국어 날짜로 포맷 (예: "2026. 3. 12.")
+ *
+ * @param isoString - ISO 8601 날짜 문자열 (예: "2026-03-12T10:32:21Z")
+ */
+export function formatDateKo(isoString: string): string {
+  return new Date(isoString).toLocaleDateString('ko-KR');
+}
+
+/**
+ * 오늘 날짜를 YYYY-MM-DD 형식으로 반환 (로컬 시간 기준)
+ */
+export function getTodayString(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
  * YYYY-MM-DD 문자열을 Date 객체로 파싱 (캘린더용)
  * @returns 유효하지 않으면 undefined
  */


### PR DESCRIPTION
## 작업 내용

### QA 기타 수정
- 회원가입 페이지 스크롤 누락 수정
- 사이드바 아이템 정렬 깨짐 수정
- 날짜 포맷 수정 및 `formatDateKo`, `getTodayString` 날짜 유틸 함수 추가
- `no-scrollbar` CSS가 적용되지 않던 레이어 우선순위 문제 수정

---

### 인증 (Auth)

**[버그] 로그인 실패 시 페이지가 새로고침되는 문제**
- 원인: 로그인 API의 401 응답이 토큰 갱신 인터셉터를 타면서, 리프레시 토큰 갱신 실패로 이어져 `window.location.href` 이동 발생
- 수정: `/users/login/` URL 포함 요청의 401은 인터셉터를 거치지 않고 바로 reject 처리

**[개선] 로그인 에러 메시지 toast로 변경**
- 기존: `form.setError`로 인라인 에러 표시 → 에러 위치가 UX상 눈에 잘 띄지 않음
- 수정: 에러 케이스별 toast 알림으로 변경
  - `USER_NOT_FOUND`: "가입된 계정을 찾을 수 없습니다"
  - `INVALID_CREDENTIALS`: "로그인 정보를 확인해 주세요"
  - `USER_NOT_CONFIRMED`: "이메일 인증이 필요합니다"

**[개선] 이메일 인증 재전송 toast 추가**
- 기존: 재전송 성공/실패 시 아무 피드백 없음 (`console.error` + TODO만 존재)
- 수정: 성공/실패 각각 toast 알림 추가

---

### 공통 컴포넌트

**AlertCard — description 줄바꿈 지원**
- 기존: `\n`이 줄바꿈으로 렌더링되지 않음
- 수정: `whitespace-pre-line` 추가

**ActionInput — 로딩 시 Spinner 교체**
- 기존: 버튼 로딩 중 `'처리중...'` 텍스트 표시
- 수정: `<Spinner size="sm" />` 으로 교체

---

### Step 1 증거 수집

**[버그] CaseHeader 제목 편집 UI 시안 불일치**
- 원인: 공용 `<Input>` 컴포넌트 사용으로 시안과 글씨체/크기/테두리 스타일 불일치
- 수정: raw `<input>` + `typo-heading-2` + `border-bottom` 스타일로 시안에 맞게 변경

**[버그] CaseHeader 제목 미변경 시에도 API 호출되는 문제**
- 원인: `confirmEdit`에서 변경 여부 비교 없이 항상 `onTitleChange` 호출
- 수정: `trimmedTitle !== title` 조건 추가로 실제 변경이 있을 때만 호출

**[버그] 증거 업로드 중 중복 업로드 가능한 문제**
- 원인: 업로드 진행 중에도 버튼 클릭 및 드래그앤드롭이 동작함
- 수정: `canUpload = !isUploading` 파생 변수로 업로드 중 버튼 disabled, 드래그앤드롭 및 클릭 차단

**[버그] 사건일지 모달 재오픈 시 이전 입력값이 남아있는 문제**
- 원인: 제출 성공 후 `reset()`이 호출되지 않아 다음에 모달을 열면 이전 입력값이 그대로 유지됨
- 수정: `reset()` + `setLocalFiles([])`를 `onSubmit` 성공 경로(`await` 이후)에 추가

**[임시] 사건일지 첨부 자료 서버 업로드 로직 제거**
- 백엔드 API 구조 변경으로 인해 기존 업로드 로직 임시 제거
- UI는 유지, 서버 연동은 API 업데이트 후 별도 작업 예정

## 이슈 번호
close #41

## 스크린샷 (선택)

- 사이드바 정렬
<img width="2128" height="1422" alt="image" src="https://github.com/user-attachments/assets/8f2fbabc-5963-4cdf-b0e0-fe01ba8809c0" />

- 제목 편집 
 <img width="728" height="130" alt="스크린샷 2026-03-12 183743" src="https://github.com/user-attachments/assets/289e5d8a-193b-42a2-bd67-f4a8ec83a391" />

- toast
<img width="2394" height="1326" alt="image" src="https://github.com/user-attachments/assets/5340db3e-b5ba-4dd4-b957-1a3a4839162b" />
