### PR TITLE
[FEAT][#45, #39]: 사건일지 첨부파일 업로드 및 수정 기능 구현

### DIFF
--- a/src/api/evidence.ts
+++ b/src/api/evidence.ts
@@ -38,6 +38,12 @@ import type {
   IncidentLogFormDataUploadRequest,
   IncidentLogFormDataResponse,
   IncidentLogFormDataUpdateRequest,
+  // INCIDENT_LOG 첨부자료
+  IncidentLogAttachmentPresignedUrlRequest,
+  IncidentLogAttachmentPresignedUrlResponse,
+  IncidentLogAttachmentRegisterRequest,
+  IncidentLogAttachmentRegisterResponse,
+  DeleteIncidentLogAttachmentsRequest,
 } from '@/types/evidence';
 
 // ─── 공통 ───────────────────────────────────────────────
@@ -296,4 +302,43 @@ export async function getIncidentLogFileOriginal(incidentLogId: string) {
     `/api/v1/evidence/incident-log/file/${incidentLogId}/original`,
   );
   return res.data;
+}
+
+// ─── INCIDENT_LOG 첨부자료 ───────────────────────────────
+
+/** 첨부자료 Presigned URL 발급 */
+export async function getIncidentLogAttachmentPresignedUrls(
+  complaintId: string,
+  incidentLogId: string,
+  payload: IncidentLogAttachmentPresignedUrlRequest,
+) {
+  const res = await axiosInstance.post<IncidentLogAttachmentPresignedUrlResponse>(
+    `/api/v1/${complaintId}/evidence/incident-log/form-data/${incidentLogId}/attachments/presigned-url`,
+    payload,
+  );
+  return res.data;
+}
+
+/** S3 업로드 완료 후 첨부자료 등록 */
+export async function registerIncidentLogAttachments(
+  complaintId: string,
+  incidentLogId: string,
+  payload: IncidentLogAttachmentRegisterRequest,
+) {
+  const res = await axiosInstance.post<IncidentLogAttachmentRegisterResponse>(
+    `/api/v1/${complaintId}/evidence/incident-log/form-data/${incidentLogId}/attachments/register`,
+    payload,
+  );
+  return res.data;
+}
+
+/** 첨부자료 삭제 (복수 삭제 지원) */
+export async function deleteIncidentLogAttachments(
+  incidentLogId: string,
+  payload: DeleteIncidentLogAttachmentsRequest,
+) {
+  await axiosInstance.delete(
+    `/api/v1/evidence/incident-log/form-data/${incidentLogId}/attachments`,
+    { data: payload },
+  );
 }

--- a/src/app/my-space/case/components/CaseHeader.tsx
+++ b/src/app/my-space/case/components/CaseHeader.tsx
@@ -112,7 +112,7 @@ export function CaseHeader({
           size="lg"
           onClick={onSave}
           loading={isSaving}
-          disabled={isSaveDisabled || isSaving}
+          disabled={isSaveDisabled}
         >
           저장
         </Button>

--- a/src/app/my-space/case/components/evidence/EvidenceCard.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceCard.tsx
@@ -30,18 +30,14 @@ interface EvidenceCardProps {
  * - Contents: EvidenceContent (드래그앤드롭/클릭/프리뷰)
  * - Footer: 개수 뱃지 + 업로드 버튼
  */
+type FormModalState = { open: false } | { open: true; initialData?: IncidentLogFormDataResponse };
+
 export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps) {
-  const [formModalOpen, setFormModalOpen] = useState(false);
-  const [editingData, setEditingData] = useState<IncidentLogFormDataResponse | null>(null);
+  const [formModal, setFormModal] = useState<FormModalState>({ open: false });
 
   const handleEdit = async (id: string) => {
     const data = await getIncidentLogFormData(id);
-    setEditingData(data);
-  };
-
-  const handleFormModalClose = () => {
-    setFormModalOpen(false);
-    setEditingData(null);
+    setFormModal({ open: true, initialData: data });
   };
   const {
     inputRef,
@@ -97,14 +93,7 @@ export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps
         </span>
         <div className="flex items-center gap-2">
           {type === 'INCIDENT_LOG' && (
-            <Button
-              color="contrast"
-              size="lg"
-              onClick={() => {
-                setEditingData(null);
-                setFormModalOpen(true);
-              }}
-            >
+            <Button color="contrast" size="lg" onClick={() => setFormModal({ open: true })}>
               <span className="flex items-center gap-2">
                 <QuoteOutlineIcon className="h-6 w-6" />
                 직접 작성
@@ -141,10 +130,10 @@ export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps
       {/* 사건일지 직접 작성 모달 */}
       {type === 'INCIDENT_LOG' && (
         <IncidentLogFormModal
-          open={formModalOpen || !!editingData}
-          onClose={handleFormModalClose}
+          open={formModal.open}
+          onClose={() => setFormModal({ open: false })}
           complaintId={complaintId}
-          initialData={editingData ?? undefined}
+          initialData={formModal.open ? formModal.initialData : undefined}
         />
       )}
 

--- a/src/app/my-space/case/components/evidence/EvidenceCard.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceCard.tsx
@@ -10,8 +10,9 @@ import { Modal } from '@/components/modals/Modal';
 import { UploadErrorModal } from './UploadErrorModal';
 import { IncidentLogFormModal } from './IncidentLogFormModal';
 import { EvidenceContent } from './EvidenceContent';
-import type { EvidenceType } from '@/types/evidence';
+import type { EvidenceType, IncidentLogFormDataResponse } from '@/types/evidence';
 import { useEvidenceCard } from '../../hooks/useEvidenceCard';
+import { getIncidentLogFormData } from '@/api/evidence';
 
 interface EvidenceCardProps {
   /** 증거 타입 (MESSAGE, VOICE 등) */
@@ -31,6 +32,17 @@ interface EvidenceCardProps {
  */
 export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps) {
   const [formModalOpen, setFormModalOpen] = useState(false);
+  const [editingData, setEditingData] = useState<IncidentLogFormDataResponse | null>(null);
+
+  const handleEdit = async (id: string) => {
+    const data = await getIncidentLogFormData(id);
+    setEditingData(data);
+  };
+
+  const handleFormModalClose = () => {
+    setFormModalOpen(false);
+    setEditingData(null);
+  };
   const {
     inputRef,
     config,
@@ -73,6 +85,7 @@ export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps
         items={items}
         onFilesAdd={handleFilesAdd}
         onRemove={handleRemove}
+        onEdit={type === 'INCIDENT_LOG' ? handleEdit : undefined}
         onClickUpload={openFilePicker}
         isUploading={isUploading}
       />
@@ -84,7 +97,14 @@ export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps
         </span>
         <div className="flex items-center gap-2">
           {type === 'INCIDENT_LOG' && (
-            <Button color="contrast" size="lg" onClick={() => setFormModalOpen(true)}>
+            <Button
+              color="contrast"
+              size="lg"
+              onClick={() => {
+                setEditingData(null);
+                setFormModalOpen(true);
+              }}
+            >
               <span className="flex items-center gap-2">
                 <QuoteOutlineIcon className="h-6 w-6" />
                 직접 작성
@@ -121,9 +141,10 @@ export function EvidenceCard({ type, complaintId, className }: EvidenceCardProps
       {/* 사건일지 직접 작성 모달 */}
       {type === 'INCIDENT_LOG' && (
         <IncidentLogFormModal
-          open={formModalOpen}
-          onClose={() => setFormModalOpen(false)}
+          open={formModalOpen || !!editingData}
+          onClose={handleFormModalClose}
           complaintId={complaintId}
+          initialData={editingData ?? undefined}
         />
       )}
 

--- a/src/app/my-space/case/components/evidence/EvidenceContent.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceContent.tsx
@@ -19,6 +19,8 @@ interface EvidenceContentProps {
   onFilesAdd: (files: File[]) => void;
   /** 증거 삭제 시 콜백 */
   onRemove: (id: string) => void;
+  /** 수정 버튼 클릭 시 콜백. isEditable 아이템에서만 hover 시 표시 */
+  onEdit?: (id: string) => void;
   /** 빈 상태 클릭 시 파일 선택 창을 여는 콜백 (EvidenceCard의 hidden input 트리거) */
   onClickUpload: () => void;
   /** 업로드 중 상태 */
@@ -37,6 +39,7 @@ export function EvidenceContent({
   items,
   onFilesAdd,
   onRemove,
+  onEdit,
   onClickUpload,
   isUploading = false,
 }: EvidenceContentProps) {
@@ -110,6 +113,7 @@ export function EvidenceContent({
                 name={item.filename ?? '파일'}
                 size={item.sizeBytes ?? 0}
                 action={{ type: 'remove', onRemove: () => onRemove(item.id) }}
+                onEdit={item.isEditable && onEdit ? () => onEdit(item.id) : undefined}
               />
             ),
           )}

--- a/src/app/my-space/case/components/evidence/FilePreview.tsx
+++ b/src/app/my-space/case/components/evidence/FilePreview.tsx
@@ -3,6 +3,7 @@ import ImageFileIcon from '@/assets/icons/ImageFileIcon.svg';
 import VoiceFileIcon from '@/assets/icons/VoiceFileIcon.svg';
 import FileDownloadIcon from '@/assets/icons/FileDownloadIcon.svg';
 import TrashOutlineIcon from '@/assets/icons/TrashOutlineIcon.svg';
+import EditOutlineIcon from '@/assets/icons/EditOutlineIcon.svg';
 import { Checkbox } from '@/components/ui/checkbox';
 import { cn } from '@/lib/utils';
 import { formatFileSize } from '@/utils/format';
@@ -21,6 +22,8 @@ interface FilePreviewProps {
   size: number;
   /** 우측 액션. 없으면 아무것도 렌더링되지 않음 */
   action?: RightAction;
+  /** 수정 버튼 콜백. 있으면 hover 시 action 좌측에 수정 아이콘 표시 */
+  onEdit?: () => void;
 }
 
 const LEFT_ICON: Record<FileCategory, React.FC<React.SVGProps<SVGSVGElement>>> = {
@@ -79,7 +82,7 @@ function RightActionSlot({ action, name }: { action: RightAction; name: string }
  * - 왼쪽: 파일명 확장자로 카테고리를 판별해 문서/이미지/음성 아이콘 표시
  * - 오른쪽: action prop에 따라 삭제 버튼 / 다운로드 버튼 / 체크박스 표시 (없으면 생략)
  */
-export function FilePreview({ name, size, action }: FilePreviewProps) {
+export function FilePreview({ name, size, action, onEdit }: FilePreviewProps) {
   const category = getCategoryFromFilename(name);
   const LeftIcon = LEFT_ICON[category];
   const formattedSize = formatFileSize(size);
@@ -87,7 +90,7 @@ export function FilePreview({ name, size, action }: FilePreviewProps) {
   return (
     <div
       className={cn(
-        'bg-bg-2 flex w-full items-center gap-2 rounded-sm border border-gray-200 px-2 py-3',
+        'group bg-bg-2 flex w-full items-center gap-2 rounded-sm border border-gray-200 px-2 py-3',
         action && 'cursor-pointer',
       )}
     >
@@ -96,6 +99,16 @@ export function FilePreview({ name, size, action }: FilePreviewProps) {
         <span className="typo-heading-6 truncate text-gray-900">{name}</span>
         <span className="typo-body-8 shrink-0 text-gray-400">{formattedSize}</span>
       </div>
+      {onEdit && (
+        <button
+          type="button"
+          onClick={onEdit}
+          className="shrink-0 text-gray-300 opacity-0 transition-opacity group-hover:opacity-100 hover:text-gray-600"
+          aria-label={`${name} 수정`}
+        >
+          <EditOutlineIcon className="h-4 w-4" />
+        </button>
+      )}
       {action && <RightActionSlot action={action} name={name} />}
     </div>
   );

--- a/src/app/my-space/case/components/evidence/IncidentLogFormModal.tsx
+++ b/src/app/my-space/case/components/evidence/IncidentLogFormModal.tsx
@@ -1,86 +1,56 @@
 'use client';
 
-import { useRef, useState } from 'react';
-import { useForm, useWatch } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import UploadIcon from '@/assets/icons/UploadIcon.svg';
 import { Button } from '@/components/Button';
 import { Input } from '@/components/Input';
 import { Modal } from '@/components/modals/Modal';
-import { useUploadIncidentLogFormData } from '../../hooks/useEvidence';
-import { EVIDENCE_CONFIG } from './constants';
-import { FilePreview } from './FilePreview';
+import type { IncidentLogFormDataResponse } from '@/types/evidence';
+import { useIncidentLogForm } from '../../hooks/useIncidentLogForm';
+import { EvidenceContent } from './EvidenceContent';
 import { getTodayString } from '@/utils/date';
 
-const incidentLogSchema = z.object({
-  filename: z.string().min(1, '제목을 입력해주세요'),
-  date: z.string().min(1, '날짜를 선택해주세요'),
-  time: z.string().min(1, '시간을 입력해주세요'),
-  location: z.string().min(1, '장소를 입력해주세요'),
-  description: z.string().min(1, '상황을 입력해주세요'),
-});
-
-type IncidentLogFormValues = z.infer<typeof incidentLogSchema>;
+// ─── UI ──────────────────────────────────────────────────
 
 interface IncidentLogFormModalProps {
   open: boolean;
   onClose: () => void;
   complaintId: string | undefined;
+  /** 수정 모드: 기존 사건일지 데이터 */
+  initialData?: IncidentLogFormDataResponse;
 }
 
-const config = EVIDENCE_CONFIG.INCIDENT_LOG;
-
-export function IncidentLogFormModal({ open, onClose, complaintId }: IncidentLogFormModalProps) {
+export function IncidentLogFormModal({
+  open,
+  onClose,
+  complaintId,
+  initialData,
+}: IncidentLogFormModalProps) {
   const today = getTodayString();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [localFiles, setLocalFiles] = useState<File[]>([]);
-  const [isDragging, setIsDragging] = useState(false);
 
   const {
-    register,
-    handleSubmit,
-    control,
-    reset,
-    formState: { errors, isValid },
-  } = useForm<IncidentLogFormValues>({
-    resolver: zodResolver(incidentLogSchema),
-    mode: 'onChange',
-    defaultValues: {
-      filename: `${today} 사건일지`,
-      date: today,
-      time: '00:00',
-      location: '',
-      description: '',
+    fileInputRef,
+    form: {
+      register,
+      handleSubmit,
+      formState: { errors, isValid },
     },
-  });
-
-  const descriptionLength = useWatch({ control, name: 'description' }).length;
-
-  const uploadFormData = useUploadIncidentLogFormData(complaintId);
-
-  const handleFilesAdd = (files: File[]) => {
-    setLocalFiles((prev) => [...prev, ...files]);
-  };
-
-  const onSubmit = async (values: IncidentLogFormValues) => {
-    await uploadFormData.mutateAsync({ ...values, witness: '', perceivedRisk: '' });
-    reset();
-    setLocalFiles([]);
-    onClose();
-  };
-
-  const isPending = uploadFormData.isPending;
+    descriptionLength,
+    attachmentItems,
+    config,
+    isSubmitting,
+    handleFilesAdd,
+    handleAttachmentRemove,
+    onSubmit,
+  } = useIncidentLogForm({ open, onClose, complaintId, initialData });
 
   return (
     <Modal.Root
       open={open}
       onOpenChange={(o) => !o && onClose()}
-      className="max-h-[90vh] w-120 flex-col"
+      className="max-h-[90vh] w-135 flex-col"
     >
       <Modal.Header title="사건일지 작성" subTitle="사건에 대해 자세하게 작성할수록 좋습니다" />
 
-      <Modal.Body className="flex flex-col gap-5 overflow-y-auto">
+      <Modal.Body className="flex flex-1 flex-col gap-5 overflow-y-auto">
         {/* 제목 */}
         <Input
           label="제목"
@@ -127,9 +97,8 @@ export function IncidentLogFormModal({ open, onClose, complaintId }: IncidentLog
           </div>
           <textarea
             maxLength={1000}
-            rows={6}
             placeholder="구체적으로 어떤 일이 있었는지 기록해주세요"
-            className="typo-body-7 w-full resize-none rounded-md border border-gray-200 bg-white px-3 py-3 text-gray-900 placeholder:text-gray-400 focus:border-gray-400 focus:outline-none"
+            className="typo-body-7 h-30 w-full resize-none rounded-md border border-gray-200 bg-white px-3 py-3 text-gray-900 placeholder:text-gray-400 focus:border-gray-400 focus:outline-none"
             {...register('description')}
           />
           {errors.description && (
@@ -141,51 +110,25 @@ export function IncidentLogFormModal({ open, onClose, complaintId }: IncidentLog
 
         {/* 증거자료 */}
         <div className="flex flex-col gap-2">
-          <p className="typo-label text-gray-700">증거자료</p>
+          <div className="flex items-center justify-between">
+            <p className="typo-label text-gray-700">증거자료</p>
+            <Button color="secondary" size="sm" onClick={() => fileInputRef.current?.click()}>
+              증거 업로드
+            </Button>
+          </div>
 
-          {/* 선택된 파일 목록 */}
-          {localFiles.length > 0 && (
-            <div className="flex flex-col gap-2">
-              {localFiles.map((file, i) => (
-                <FilePreview
-                  key={i}
-                  name={file.name}
-                  size={file.size}
-                  action={{
-                    type: 'remove',
-                    onRemove: () => setLocalFiles((prev) => prev.filter((_, idx) => idx !== i)),
-                  }}
-                />
-              ))}
-            </div>
-          )}
-
-          {/* 업로드 영역 */}
-          {localFiles.length < config.maxFiles && (
-            <div
-              role="button"
-              tabIndex={0}
-              onClick={() => fileInputRef.current?.click()}
-              onKeyDown={(e) => e.key === 'Enter' && fileInputRef.current?.click()}
-              onDragOver={(e) => {
-                e.preventDefault();
-                setIsDragging(true);
-              }}
-              onDragLeave={() => setIsDragging(false)}
-              onDrop={(e) => {
-                e.preventDefault();
-                setIsDragging(false);
-                handleFilesAdd(Array.from(e.dataTransfer.files));
-              }}
-              className={`bg-bg-2 flex cursor-pointer flex-col items-center gap-2 rounded-lg border-[1.5px] border-dashed py-8 transition-colors ${isDragging ? 'border-primary bg-primary/5' : 'border-gray-200'}`}
-            >
-              <UploadIcon className="h-6 w-6 text-gray-400" />
-              <p className="typo-heading-4 text-gray-400">증거 업로드</p>
-              <p className="typo-body-7 text-gray-400">
-                클릭하거나 드래그앤드롭으로 자료를 업로드해주세요
-              </p>
-            </div>
-          )}
+          {/* 파일 2.5개 이상부터 스크롤 — 빈 상태(업로드 존)엔 높이 제한 없음 */}
+          <div
+            className={attachmentItems.length > 0 ? 'no-scrollbar max-h-28 overflow-y-auto' : ''}
+          >
+            <EvidenceContent
+              previewType="file"
+              items={attachmentItems}
+              onFilesAdd={handleFilesAdd}
+              onRemove={handleAttachmentRemove}
+              onClickUpload={() => fileInputRef.current?.click()}
+            />
+          </div>
 
           <input
             ref={fileInputRef}
@@ -206,9 +149,9 @@ export function IncidentLogFormModal({ open, onClose, complaintId }: IncidentLog
           color="contrast"
           size="xl"
           onClick={handleSubmit(onSubmit)}
-          disabled={!isValid || isPending}
+          disabled={!isValid || isSubmitting}
         >
-          {isPending ? '저장 중...' : '작성하기'}
+          {isSubmitting ? '저장 중...' : '작성하기'}
         </Button>
       </Modal.Footer>
     </Modal.Root>

--- a/src/app/my-space/case/components/evidence/IncidentLogFormModal.tsx
+++ b/src/app/my-space/case/components/evidence/IncidentLogFormModal.tsx
@@ -36,6 +36,8 @@ export function IncidentLogFormModal({
     descriptionLength,
     attachmentItems,
     config,
+    isEditMode,
+    isChanged,
     isSubmitting,
     handleFilesAdd,
     handleAttachmentRemove,
@@ -48,7 +50,10 @@ export function IncidentLogFormModal({
       onOpenChange={(o) => !o && onClose()}
       className="max-h-[90vh] w-135 flex-col"
     >
-      <Modal.Header title="사건일지 작성" subTitle="사건에 대해 자세하게 작성할수록 좋습니다" />
+      <Modal.Header
+        title={isEditMode ? '사건일지 수정' : '사건일지 작성'}
+        subTitle="사건에 대해 자세하게 작성할수록 좋습니다"
+      />
 
       <Modal.Body className="flex flex-1 flex-col gap-5 overflow-y-auto">
         {/* 제목 */}
@@ -149,9 +154,10 @@ export function IncidentLogFormModal({
           color="contrast"
           size="xl"
           onClick={handleSubmit(onSubmit)}
-          disabled={!isValid || isSubmitting}
+          disabled={isEditMode ? !isChanged : !isValid}
+          loading={isSubmitting}
         >
-          {isSubmitting ? '저장 중...' : '작성하기'}
+          {isEditMode ? '수정하기' : '작성하기'}
         </Button>
       </Modal.Footer>
     </Modal.Root>

--- a/src/app/my-space/case/components/evidence/IncidentLogFormModal.tsx
+++ b/src/app/my-space/case/components/evidence/IncidentLogFormModal.tsx
@@ -35,7 +35,7 @@ export function IncidentLogFormModal({
     },
     descriptionLength,
     attachmentItems,
-    config,
+    attachmentConfig: config,
     isEditMode,
     isChanged,
     isSubmitting,

--- a/src/app/my-space/case/components/evidence/constants.ts
+++ b/src/app/my-space/case/components/evidence/constants.ts
@@ -114,7 +114,7 @@ export const EVIDENCE_CONFIG = withAccept({
   },
   INCIDENT_LOG: {
     maxFiles: 3,
-    categories: ['DOCUMENT'] as FileCategoryKey[],
+    categories: ['IMAGE', 'VIDEO', 'AUDIO', 'DOCUMENT'] as FileCategoryKey[],
     previewType: 'file' as const,
     title: '사건 일지',
     description: '일어난 사건에 대한 내용을 작성한 기록',

--- a/src/app/my-space/case/components/evidence/constants.ts
+++ b/src/app/my-space/case/components/evidence/constants.ts
@@ -114,7 +114,7 @@ export const EVIDENCE_CONFIG = withAccept({
   },
   INCIDENT_LOG: {
     maxFiles: 3,
-    categories: ['IMAGE', 'VIDEO', 'AUDIO', 'DOCUMENT'] as FileCategoryKey[],
+    categories: ['DOCUMENT'] as FileCategoryKey[],
     previewType: 'file' as const,
     title: '사건 일지',
     description: '일어난 사건에 대한 내용을 작성한 기록',

--- a/src/app/my-space/case/components/evidence/validate.ts
+++ b/src/app/my-space/case/components/evidence/validate.ts
@@ -80,7 +80,7 @@ export type FilterResult = {
  */
 export const filterValidFiles = async (
   newFiles: File[],
-  config: EvidenceConfig,
+  config: Pick<EvidenceConfig, 'maxFiles' | 'categories'>,
   currentCount: number,
 ): Promise<FilterResult> => {
   const remaining = config.maxFiles - currentCount;

--- a/src/app/my-space/case/components/evidence/validate.ts
+++ b/src/app/my-space/case/components/evidence/validate.ts
@@ -1,5 +1,6 @@
 import { FILE_CATEGORY_CONFIG } from './constants';
 import type { EVIDENCE_CONFIG, FileCategoryKey, EvidenceType } from './constants';
+import type { PresignedUrlItemRequest } from '@/types/evidence';
 
 type EvidenceConfig = (typeof EVIDENCE_CONFIG)[EvidenceType];
 
@@ -41,6 +42,31 @@ export const getMediaDuration = (file: File): Promise<number> => {
     video.src = URL.createObjectURL(file);
   });
 };
+
+/**
+ * 파일 배열을 Presigned URL 요청 형식으로 변환
+ * - IMAGE/DOCUMENT는 duration 측정 없이 자동 통과
+ * - VIDEO/AUDIO는 실제 재생 길이를 측정해서 포함
+ */
+export async function buildPresignedUrlItems(
+  files: File[],
+  categories: FileCategoryKey[],
+): Promise<PresignedUrlItemRequest[]> {
+  const fileCategories = files.map((f) => getCategoryForFile(f, categories));
+  const durations = await Promise.all(
+    files.map(async (f, i) => {
+      if (!fileCategories[i]?.maxDuration) return null;
+      return getMediaDuration(f);
+    }),
+  );
+  return files.map((file, i) => ({
+    index: i,
+    filename: file.name,
+    contentType: file.type,
+    sizeBytes: file.size,
+    ...(durations[i] !== null ? { durationSeconds: Math.round(durations[i]!) } : {}),
+  }));
+}
 
 export type FilterResult = {
   valid: File[];

--- a/src/app/my-space/case/hooks/useEvidence.ts
+++ b/src/app/my-space/case/hooks/useEvidence.ts
@@ -21,7 +21,6 @@ import {
 import type {
   EvidenceType,
   EvidencePreviewItem,
-  PresignedUrlItemRequest,
   IncidentLogFormDataUploadRequest,
   IncidentLogFormDataUpdateRequest,
   MessageDetailListResponse,
@@ -31,7 +30,7 @@ import type {
   IncidentLogDetailListResponse,
 } from '@/types/evidence';
 import { EVIDENCE_CONFIG } from '../components/evidence/constants';
-import { getMediaDuration, getCategoryForFile } from '../components/evidence/validate';
+import { buildPresignedUrlItems } from '../components/evidence/validate';
 
 // ─── query key ──────────────────────────────────────────
 
@@ -195,22 +194,7 @@ export function useUploadEvidence(complaintId: string | undefined, type: Evidenc
   return useMutation({
     mutationFn: async (files: File[]) => {
       // 1) presigned URL 발급
-      // 영상·음성 파일만 실제 재생 길이를 구해서 전달 (이미지는 제외)
-      const fileCategories = files.map((f) => getCategoryForFile(f, config.categories));
-      const durations: (number | null)[] = await Promise.all(
-        files.map(async (f, i) => {
-          if (!fileCategories[i]?.maxDuration) return null;
-          return getMediaDuration(f);
-        }),
-      );
-
-      const presignedItems: PresignedUrlItemRequest[] = files.map((file, i) => ({
-        index: i,
-        filename: file.name,
-        contentType: file.type,
-        sizeBytes: file.size,
-        ...(durations[i] !== null ? { durationSeconds: Math.round(durations[i]!) } : {}),
-      }));
+      const presignedItems = await buildPresignedUrlItems(files, config.categories);
 
       const { items: presignedUrls } = await getPresignedUrls(complaintId!, {
         type,

--- a/src/app/my-space/case/hooks/useEvidence.ts
+++ b/src/app/my-space/case/hooks/useEvidence.ts
@@ -10,6 +10,7 @@ import {
   registerReportRecords,
   registerIncidentLogFiles,
   uploadIncidentLogFormData,
+  updateIncidentLogFormData,
   // 타입별 detail
   getMessageDetails,
   getVoiceDetails,
@@ -22,6 +23,7 @@ import type {
   EvidencePreviewItem,
   PresignedUrlItemRequest,
   IncidentLogFormDataUploadRequest,
+  IncidentLogFormDataUpdateRequest,
   MessageDetailListResponse,
   VoiceDetailListResponse,
   VictimDetailListResponse,
@@ -107,6 +109,7 @@ const fetchAndNormalize: Record<
         id: d.incident_log_id,
         filename: d.filename,
         sizeBytes: d.size_bytes ?? undefined,
+        isEditable: d.type === 'FORM_DATA',
       })),
       totalCount: res.total_count,
     };
@@ -255,6 +258,37 @@ export function useUploadIncidentLogFormData(complaintId: string | undefined) {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: evidenceKeys.previews(complaintId!, 'INCIDENT_LOG'),
+      });
+    },
+  });
+}
+
+// ─── 사건일지 폼 데이터 수정 훅 ─────────────────────────
+
+/**
+ * 사건일지 직접 작성(폼 데이터) 수정 훅
+ *
+ * - 날짜, 장소, 상황 등을 Partial로 PATCH 전송
+ * - 성공 시 INCIDENT_LOG 목록 자동 갱신
+ *
+ * @param complaintId - 고소장 ID (invalidateQueries에 사용)
+ * @returns useMutation — mutate({ incidentLogId, payload })로 호출
+ */
+export function useUpdateIncidentLogFormData(complaintId: string | undefined) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      incidentLogId,
+      payload,
+    }: {
+      incidentLogId: string;
+      payload: IncidentLogFormDataUpdateRequest;
+    }) => updateIncidentLogFormData(incidentLogId, payload),
+    onSuccess: () => {
+      if (!complaintId) return;
+      queryClient.invalidateQueries({
+        queryKey: evidenceKeys.previews(complaintId, 'INCIDENT_LOG'),
       });
     },
   });

--- a/src/app/my-space/case/hooks/useIncidentLogForm.ts
+++ b/src/app/my-space/case/hooks/useIncidentLogForm.ts
@@ -1,0 +1,210 @@
+import { useEffect, useRef, useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  uploadToS3,
+  getIncidentLogAttachmentPresignedUrls,
+  registerIncidentLogAttachments,
+  deleteIncidentLogAttachments,
+} from '@/api/evidence';
+import type { IncidentLogAttachment, IncidentLogFormDataResponse } from '@/types/evidence';
+import type { EvidencePreviewItem } from '@/types/evidence';
+import { EVIDENCE_CONFIG } from '../components/evidence/constants';
+import {
+  filterValidFiles,
+  getCategoryForFile,
+  getMediaDuration,
+} from '../components/evidence/validate';
+import { useUploadIncidentLogFormData } from './useEvidence';
+import { getTodayString } from '@/utils/date';
+
+// ─── 검증 ────────────────────────────────────────────────
+
+export const incidentLogSchema = z.object({
+  filename: z.string().min(1, '제목을 입력해주세요'),
+  date: z.string().min(1, '날짜를 선택해주세요'),
+  time: z.string().min(1, '시간을 입력해주세요'),
+  location: z.string().min(1, '장소를 입력해주세요'),
+  description: z.string().min(1, '상황을 입력해주세요'),
+});
+
+export type IncidentLogFormValues = z.infer<typeof incidentLogSchema>;
+
+/** 로컬 파일에 안정적인 임시 ID를 부여해 삭제 시 인덱스 충돌을 방지함 */
+type LocalFile = { id: string; file: File };
+
+const config = EVIDENCE_CONFIG.INCIDENT_LOG;
+
+// ─── 기능 ────────────────────────────────────────────────
+
+interface UseIncidentLogFormParams {
+  open: boolean;
+  onClose: () => void;
+  complaintId: string | undefined;
+  initialData?: IncidentLogFormDataResponse;
+}
+
+/**
+ * 사건일지 작성 모달 로직 훅
+ *
+ * - 폼 상태 관리 (react-hook-form)
+ * - 첨부파일 추가/제거 (로컬 + 서버)
+ * - 제출 시 폼 데이터 업로드 → 첨부파일 일괄 삭제 → 신규 파일 업로드
+ */
+export function useIncidentLogForm({
+  open,
+  onClose,
+  complaintId,
+  initialData,
+}: UseIncidentLogFormParams) {
+  const today = getTodayString();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [localFiles, setLocalFiles] = useState<LocalFile[]>([]);
+  const [serverAttachments, setServerAttachments] = useState<IncidentLogAttachment[]>([]);
+  const [pendingDeleteIds, setPendingDeleteIds] = useState<string[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<IncidentLogFormValues>({
+    resolver: zodResolver(incidentLogSchema),
+    mode: 'onChange',
+    defaultValues: {
+      filename: `${today} 사건일지`,
+      date: today,
+      time: '00:00',
+      location: '',
+      description: '',
+    },
+  });
+
+  const descriptionLength = useWatch({ control: form.control, name: 'description' }).length;
+  const uploadFormData = useUploadIncidentLogFormData(complaintId);
+
+  /** 모달 열릴 때마다 상태 초기화 (수정 모드면 기존 데이터로 채움) */
+  useEffect(() => {
+    if (!open) return;
+    setServerAttachments(initialData?.attachments ?? []);
+    setPendingDeleteIds([]);
+    setLocalFiles([]);
+    form.reset({
+      filename: initialData?.filename ?? `${today} 사건일지`,
+      date: initialData?.date ?? today,
+      time: initialData?.time ?? '00:00',
+      location: initialData?.location ?? '',
+      description: initialData?.description ?? '',
+    });
+    // open이 true로 바뀔 때만 초기화하면 되므로 의도적으로 의존성 생략
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  /** 새 파일 추가 — 카테고리별 크기·길이 검증 후 임시 ID 부여 */
+  const handleFilesAdd = async (files: File[]) => {
+    const { valid } = await filterValidFiles(
+      files,
+      { ...config, maxFiles: 10 },
+      localFiles.length + serverAttachments.length,
+    );
+    setLocalFiles((prev) => [...prev, ...valid.map((file) => ({ id: crypto.randomUUID(), file }))]);
+  };
+
+  /** 파일 제거 — 로컬이면 상태에서 삭제, 서버면 삭제 예정 목록에 추가 */
+  const handleAttachmentRemove = (id: string) => {
+    if (localFiles.some((f) => f.id === id)) {
+      setLocalFiles((prev) => prev.filter((f) => f.id !== id));
+    } else {
+      setPendingDeleteIds((prev) => [...prev, id]);
+      setServerAttachments((prev) => prev.filter((a) => a.attachment_id !== id));
+    }
+  };
+
+  /** 서버 첨부파일 + 로컬 파일을 EvidenceContent용 통일 형식으로 변환 */
+  const attachmentItems: EvidencePreviewItem[] = [
+    ...serverAttachments.map((a) => ({
+      id: a.attachment_id,
+      filename: a.filename,
+      sizeBytes: a.size_bytes,
+    })),
+    ...localFiles.map(({ id, file }) => ({
+      id,
+      filename: file.name,
+      sizeBytes: file.size,
+    })),
+  ];
+
+  const onSubmit = async (values: IncidentLogFormValues) => {
+    setIsSubmitting(true);
+    try {
+      const { incident_log_id } = await uploadFormData.mutateAsync(values);
+
+      if (complaintId) {
+        // 삭제 예정 첨부파일 일괄 삭제
+        if (pendingDeleteIds.length > 0) {
+          await deleteIncidentLogAttachments(incident_log_id, {
+            attachmentIds: pendingDeleteIds,
+          });
+        }
+
+        // 신규 첨부파일 업로드 (presigned URL → S3 → register)
+        if (localFiles.length > 0) {
+          const files = localFiles.map((f) => f.file);
+          const fileCategories = files.map((f) => getCategoryForFile(f, config.categories));
+          const durations = await Promise.all(
+            files.map(async (f, i) => {
+              if (!fileCategories[i]?.maxDuration) return null;
+              return getMediaDuration(f);
+            }),
+          );
+
+          const { items: presignedItems } = await getIncidentLogAttachmentPresignedUrls(
+            complaintId,
+            incident_log_id,
+            {
+              items: files.map((file, i) => ({
+                index: i,
+                filename: file.name,
+                contentType: file.type,
+                sizeBytes: file.size,
+                ...(durations[i] !== null ? { durationSeconds: Math.round(durations[i]!) } : {}),
+              })),
+            },
+          );
+
+          await Promise.all(presignedItems.map((p, i) => uploadToS3(p.url, files[i])));
+
+          await registerIncidentLogAttachments(complaintId, incident_log_id, {
+            items: presignedItems.map((p) => ({
+              attachmentId: p.attachment_id,
+              filename: p.filename,
+            })),
+          });
+        }
+      }
+
+      onClose();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    // Refs
+    fileInputRef,
+
+    // 폼
+    form,
+    descriptionLength,
+
+    // 첨부파일
+    attachmentItems,
+    config,
+
+    // 상태
+    isSubmitting,
+
+    // 핸들러
+    handleFilesAdd,
+    handleAttachmentRemove,
+    onSubmit,
+  };
+}

--- a/src/app/my-space/case/hooks/useIncidentLogForm.ts
+++ b/src/app/my-space/case/hooks/useIncidentLogForm.ts
@@ -13,8 +13,8 @@ import type {
   IncidentLogFormDataResponse,
   EvidencePreviewItem,
 } from '@/types/evidence';
-import { EVIDENCE_CONFIG } from '../components/evidence/constants';
 import { filterValidFiles, buildPresignedUrlItems } from '../components/evidence/validate';
+import type { FileCategoryKey } from '../components/evidence/constants';
 import { useUploadIncidentLogFormData, useUpdateIncidentLogFormData } from './useEvidence';
 import { getTodayString } from '@/utils/date';
 
@@ -33,7 +33,12 @@ export type IncidentLogFormValues = z.infer<typeof incidentLogSchema>;
 /** 로컬 파일에 안정적인 임시 ID를 부여해 삭제 시 인덱스 충돌을 방지함 */
 type LocalFile = { id: string; file: File };
 
-const config = EVIDENCE_CONFIG.INCIDENT_LOG;
+/** 직접 작성 모달 첨부파일 설정 — 파일 업로드(DOCUMENT 전용)와 별도 */
+const attachmentConfig = {
+  maxFiles: 10,
+  categories: ['IMAGE', 'VIDEO', 'AUDIO', 'DOCUMENT'] as FileCategoryKey[],
+  accept: '.jpg,.jpeg,.png,.heic,.mp4,.mov,.m4a,.mp3,.wav,.pdf,.hwp,.docx,.txt',
+};
 
 /** presigned URL 발급 → S3 업로드 → 서버 등록 */
 async function uploadAttachments(
@@ -42,7 +47,7 @@ async function uploadAttachments(
   localFiles: { id: string; file: File }[],
 ) {
   const files = localFiles.map((f) => f.file);
-  const presignedUrlItems = await buildPresignedUrlItems(files, config.categories);
+  const presignedUrlItems = await buildPresignedUrlItems(files, attachmentConfig.categories);
 
   const { items: presignedItems } = await getIncidentLogAttachmentPresignedUrls(
     complaintId,
@@ -130,7 +135,7 @@ export function useIncidentLogForm({
   const handleFilesAdd = async (files: File[]) => {
     const { valid } = await filterValidFiles(
       files,
-      { ...config, maxFiles: 10 },
+      { ...attachmentConfig, maxFiles: 10 },
       localFiles.length + serverAttachments.length,
     );
     setLocalFiles((prev) => [...prev, ...valid.map((file) => ({ id: crypto.randomUUID(), file }))]);
@@ -200,7 +205,7 @@ export function useIncidentLogForm({
 
     // 첨부파일
     attachmentItems,
-    config,
+    attachmentConfig,
 
     // 상태
     isEditMode,

--- a/src/app/my-space/case/hooks/useIncidentLogForm.ts
+++ b/src/app/my-space/case/hooks/useIncidentLogForm.ts
@@ -16,7 +16,7 @@ import {
   getCategoryForFile,
   getMediaDuration,
 } from '../components/evidence/validate';
-import { useUploadIncidentLogFormData } from './useEvidence';
+import { useUploadIncidentLogFormData, useUpdateIncidentLogFormData } from './useEvidence';
 import { getTodayString } from '@/utils/date';
 
 // ─── 검증 ────────────────────────────────────────────────
@@ -80,6 +80,10 @@ export function useIncidentLogForm({
 
   const descriptionLength = useWatch({ control: form.control, name: 'description' }).length;
   const uploadFormData = useUploadIncidentLogFormData(complaintId);
+  const updateFormData = useUpdateIncidentLogFormData(complaintId);
+
+  const isEditMode = !!initialData;
+  const isChanged = form.formState.isDirty || localFiles.length > 0 || pendingDeleteIds.length > 0;
 
   /** 모달 열릴 때마다 상태 초기화 (수정 모드면 기존 데이터로 채움) */
   useEffect(() => {
@@ -135,7 +139,12 @@ export function useIncidentLogForm({
   const onSubmit = async (values: IncidentLogFormValues) => {
     setIsSubmitting(true);
     try {
-      const { incident_log_id } = await uploadFormData.mutateAsync(values);
+      const { incident_log_id } = isEditMode
+        ? await updateFormData.mutateAsync({
+            incidentLogId: initialData.incident_log_id,
+            payload: values,
+          })
+        : await uploadFormData.mutateAsync(values);
 
       if (complaintId) {
         // 삭제 예정 첨부파일 일괄 삭제
@@ -200,6 +209,8 @@ export function useIncidentLogForm({
     config,
 
     // 상태
+    isEditMode,
+    isChanged,
     isSubmitting,
 
     // 핸들러

--- a/src/app/my-space/case/hooks/useIncidentLogForm.ts
+++ b/src/app/my-space/case/hooks/useIncidentLogForm.ts
@@ -8,14 +8,13 @@ import {
   registerIncidentLogAttachments,
   deleteIncidentLogAttachments,
 } from '@/api/evidence';
-import type { IncidentLogAttachment, IncidentLogFormDataResponse } from '@/types/evidence';
-import type { EvidencePreviewItem } from '@/types/evidence';
+import type {
+  IncidentLogAttachment,
+  IncidentLogFormDataResponse,
+  EvidencePreviewItem,
+} from '@/types/evidence';
 import { EVIDENCE_CONFIG } from '../components/evidence/constants';
-import {
-  filterValidFiles,
-  getCategoryForFile,
-  getMediaDuration,
-} from '../components/evidence/validate';
+import { filterValidFiles, buildPresignedUrlItems } from '../components/evidence/validate';
 import { useUploadIncidentLogFormData, useUpdateIncidentLogFormData } from './useEvidence';
 import { getTodayString } from '@/utils/date';
 
@@ -35,6 +34,31 @@ export type IncidentLogFormValues = z.infer<typeof incidentLogSchema>;
 type LocalFile = { id: string; file: File };
 
 const config = EVIDENCE_CONFIG.INCIDENT_LOG;
+
+/** presigned URL 발급 → S3 업로드 → 서버 등록 */
+async function uploadAttachments(
+  complaintId: string,
+  incidentLogId: string,
+  localFiles: { id: string; file: File }[],
+) {
+  const files = localFiles.map((f) => f.file);
+  const presignedUrlItems = await buildPresignedUrlItems(files, config.categories);
+
+  const { items: presignedItems } = await getIncidentLogAttachmentPresignedUrls(
+    complaintId,
+    incidentLogId,
+    { items: presignedUrlItems },
+  );
+
+  await Promise.all(presignedItems.map((p, i) => uploadToS3(p.url, files[i])));
+
+  await registerIncidentLogAttachments(complaintId, incidentLogId, {
+    items: presignedItems.map((p) => ({
+      attachmentId: p.attachment_id,
+      filename: p.filename,
+    })),
+  });
+}
 
 // ─── 기능 ────────────────────────────────────────────────
 
@@ -156,37 +180,7 @@ export function useIncidentLogForm({
 
         // 신규 첨부파일 업로드 (presigned URL → S3 → register)
         if (localFiles.length > 0) {
-          const files = localFiles.map((f) => f.file);
-          const fileCategories = files.map((f) => getCategoryForFile(f, config.categories));
-          const durations = await Promise.all(
-            files.map(async (f, i) => {
-              if (!fileCategories[i]?.maxDuration) return null;
-              return getMediaDuration(f);
-            }),
-          );
-
-          const { items: presignedItems } = await getIncidentLogAttachmentPresignedUrls(
-            complaintId,
-            incident_log_id,
-            {
-              items: files.map((file, i) => ({
-                index: i,
-                filename: file.name,
-                contentType: file.type,
-                sizeBytes: file.size,
-                ...(durations[i] !== null ? { durationSeconds: Math.round(durations[i]!) } : {}),
-              })),
-            },
-          );
-
-          await Promise.all(presignedItems.map((p, i) => uploadToS3(p.url, files[i])));
-
-          await registerIncidentLogAttachments(complaintId, incident_log_id, {
-            items: presignedItems.map((p) => ({
-              attachmentId: p.attachment_id,
-              filename: p.filename,
-            })),
-          });
+          await uploadAttachments(complaintId, incident_log_id, localFiles);
         }
       }
 

--- a/src/types/evidence.ts
+++ b/src/types/evidence.ts
@@ -316,11 +316,19 @@ export type IncidentLogFormDataUploadRequest = {
   time: string; // HH:MM
   location: string;
   description: string;
-  witness: string;
-  perceivedRisk: string; // 매우 높음 | 높음 | 보통 | 낮음 | 매우 낮음
 };
 
 export type IncidentLogFormDataUpdateRequest = Partial<IncidentLogFormDataUploadRequest>;
+
+export type IncidentLogAttachment = {
+  attachment_id: string;
+  type: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  duration_seconds: number | null;
+  created_at: string;
+};
 
 export type IncidentLogFormDataResponse = {
   incident_log_id: string;
@@ -329,10 +337,52 @@ export type IncidentLogFormDataResponse = {
   time: string;
   location: string;
   description: string;
-  witness: string;
-  perceived_risk: string;
+  attachments: IncidentLogAttachment[];
   created_at: string;
   updated_at: string;
+};
+
+// ─── INCIDENT_LOG 첨부자료 ───────────────────────────────
+
+export type IncidentLogAttachmentPresignedUrlRequest = {
+  items: PresignedUrlItemRequest[];
+};
+
+export type IncidentLogAttachmentPresignedUrlItemResponse = {
+  index: number;
+  filename: string;
+  url: string;
+  attachment_id: string;
+};
+
+export type IncidentLogAttachmentPresignedUrlResponse = {
+  items: IncidentLogAttachmentPresignedUrlItemResponse[];
+};
+
+export type IncidentLogAttachmentRegisterItem = {
+  attachmentId: string;
+  filename: string;
+};
+
+export type IncidentLogAttachmentRegisterRequest = {
+  items: IncidentLogAttachmentRegisterItem[];
+};
+
+export type IncidentLogAttachmentRegisterItemResponse = {
+  attachment_id: string;
+  type: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  duration_seconds: number | null;
+};
+
+export type IncidentLogAttachmentRegisterResponse = {
+  items: IncidentLogAttachmentRegisterItemResponse[];
+};
+
+export type DeleteIncidentLogAttachmentsRequest = {
+  attachmentIds: string[];
 };
 
 /** 프리뷰 / 상세 (FILE + FORM_DATA 혼합) */

--- a/src/types/evidence.ts
+++ b/src/types/evidence.ts
@@ -432,6 +432,8 @@ export type EvidencePreviewItem = {
   thumbnailUrl?: string;
   sizeBytes?: number;
   durationSeconds?: number;
+  /** 수정 가능한 아이템 여부 (INCIDENT_LOG FORM_DATA 타입만 true) */
+  isEditable?: boolean;
 };
 
 // ─── 에러 응답 ──────────────────────────────────────────


### PR DESCRIPTION
## 작업 내용

### 1. 타입 및 API 추가

**`src/types/evidence.ts`**
- `IncidentLogFormDataUploadRequest`에서 `witness`, `perceivedRisk` 제거 (백엔드 스펙 변경 반영)
- `IncidentLogFormDataResponse`에 `attachments: IncidentLogAttachment[]` 추가
- 첨부자료 관련 타입 추가: `IncidentLogAttachment`, `IncidentLogAttachmentPresignedUrlRequest/Response`, `IncidentLogAttachmentRegisterRequest/Response`, `DeleteIncidentLogAttachmentsRequest`
- `EvidencePreviewItem`에 `isEditable?: boolean` 추가 — FORM_DATA 타입만 수정 버튼 표시됩니다.

**`src/api/evidence.ts`**
- 첨부자료 API 함수 3개를 추가했습니다.
  - `getIncidentLogAttachmentPresignedUrls` — S3 업로드용 presigned URL 발급
  - `registerIncidentLogAttachments` — S3 업로드 완료 후 서버 등록
  - `deleteIncidentLogAttachments` — 첨부자료 복수 삭제

---

### 2. 사건일지 작성 모달 첨부파일 기능 (`useIncidentLogForm.ts` 신규)

`useEvidenceCard` 패턴을 따라 로직을 훅으로 분리했습니다. 모달 컴포넌트는 UI만 담당합니다.

**상태 구조**
- `localFiles` — 새로 추가한 파일 (아직 서버 미등록, `crypto.randomUUID()`로 임시 ID 부여)
- `serverAttachments` — 서버에서 받아온 기존 첨부파일
- `pendingDeleteIds` — 삭제 예정인 서버 첨부파일 ID 목록 (submit 시 일괄 처리)

**제출 플로우**
```
폼 데이터 저장 (POST/PATCH) → incident_log_id 획득
  → pendingDeleteIds 일괄 삭제
  → 신규 파일 presigned URL 발급 → S3 업로드 → 서버 등록
```

**생성/수정 모드 분기**
- `initialData` 유무로 자동 결정됩니다. (`isEditMode = !!initialData`)
- 생성: POST, '작성하기' 버튼, `isValid`로 활성화
- 수정: PATCH, '수정하기' 버튼, `isChanged`로 활성화 (`isDirty || 신규파일 || 삭제예정`)

---

### 3. 수정 버튼 UI

**`FilePreview.tsx`** — `onEdit` prop 추가, hover 시 `EditOutlineIcon` 표시 (`group-hover:opacity-100`)

**`EvidenceContent.tsx`** — `onEdit` prop 추가, `item.isEditable`인 경우에만 FilePreview에 전달됩니다.

**`EvidenceCard.tsx`** — `FormModalState` discriminated union으로 모달 상태를 관리합니다.
```typescript
type FormModalState =
  | { open: false }
  | { open: true; initialData?: IncidentLogFormDataResponse };
```
수정 버튼 클릭 시 `getIncidentLogFormData(id)` 조회 후 `initialData`와 함께 모달이 열립니다.

---

### 4. 리팩토링 및 수정

- `buildPresignedUrlItems` — `validate.ts`로 추출해 `useEvidence` / `useIncidentLogForm`에서 공유합니다. (기존 중복 제거)
- `uploadAttachments` — `onSubmit` 내 업로드 세부 구현을 모듈 레벨 함수로 분리했습니다.
- `Button` `loading` prop 활용으로 `disabled` 조건에서 `isSubmitting`을 제거했습니다. (`IncidentLogFormModal`, `CaseHeader`)
- 사건일지 파일 업로드 타입을 문서(DOCUMENT)로 수정했습니다.
- 직접 작성 모달 첨부파일은 IMAGE / VIDEO / AUDIO / DOCUMENT 모두 허용되도록 `attachmentConfig`를 별도로 분리했습니다. (`EVIDENCE_CONFIG.INCIDENT_LOG`와 독립)

### 추후 작업 필요
 - 모달 내부 날짜, 시간 선택 UI 디자이너와 합의 후 구현 

## 이슈 번호

close #45, #39

## 스크린샷 (선택)

### 사건일지 직접 작성 모달
<img width="600" alt="image" src="https://github.com/user-attachments/assets/d1362b54-fe96-4901-a63c-da4108d73ebd" />

### 작성 완료 후 업로드 확인
<img width="500" alt="스크린샷 2026-03-19 170851" src="https://github.com/user-attachments/assets/b2e46fa4-a0ff-4df4-b85a-9a6c9c2a74ca" />
<img width="500" alt="스크린샷 2026-03-19 170905" src="https://github.com/user-attachments/assets/669e072b-879e-44d5-bce7-c9c75c1c89a1" />
<img width="500" alt="스크린샷 2026-03-19 170915" src="https://github.com/user-attachments/assets/7ec2e301-9c0a-4a31-9fed-cbc8fb1669ba" />

### 수정 확인
- 직접 작성 사건일지만 hover 시 수정 버튼이 나타납니다. (디자이너 협의 후 수정 가능성 있음)
<img width="500" alt="스크린샷 2026-03-19 174123" src="https://github.com/user-attachments/assets/f0fac32a-5b55-4440-af50-75df7e2f1317" />

- 수정 사항 없을 시 버튼이 비활성화됩니다.
<img width="400" alt="스크린샷 2026-03-19 174132" src="https://github.com/user-attachments/assets/4b3f8cac-e1d1-47a9-8d81-52d36301c58a" />

- 수정 사항 있을 시 버튼이 활성화됩니다.
<img width="400" alt="스크린샷 2026-03-19 174140" src="https://github.com/user-attachments/assets/3ac16d9b-9626-4f70-84bb-fe8ce03d21ef" />

- PATCH 후 데이터가 갱신됩니다.
<img width="500" alt="스크린샷 2026-03-19 174215" src="https://github.com/user-attachments/assets/8264b9f9-0437-4b1a-a838-5ea8f0d35bdf" />
