### PR TITLE
[FEAT]: Suspense + ErrorBoundary 도입 (CasePage)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "19.2.3",
     "react-day-picker": "^9.13.0",
     "react-dom": "19.2.3",
+    "react-error-boundary": "^6.1.1",
     "react-hook-form": "^7.71.1",
     "react-toastify": "^11.0.5",
     "tailwind-merge": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      react-error-boundary:
+        specifier: ^6.1.1
+        version: 6.1.1(react@19.2.3)
       react-hook-form:
         specifier: ^7.71.1
         version: 7.71.1(react@19.2.3)
@@ -2999,6 +3002,11 @@ packages:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
       react: ^19.2.3
+
+  react-error-boundary@6.1.1:
+    resolution: {integrity: sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
 
   react-hook-form@7.71.1:
     resolution: {integrity: sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==}
@@ -6511,6 +6519,10 @@ snapshots:
     dependencies:
       react: 19.2.3
       scheduler: 0.27.0
+
+  react-error-boundary@6.1.1(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   react-hook-form@7.71.1(react@19.2.3):
     dependencies:

--- a/src/app/my-space/case/components/StepCollect.tsx
+++ b/src/app/my-space/case/components/StepCollect.tsx
@@ -8,7 +8,7 @@ const LEFT_TYPES: EvidenceType[] = ['MESSAGE', 'VICTIM'];
 const RIGHT_TYPES: EvidenceType[] = ['VOICE', 'REPORT_RECORD', 'INCIDENT_LOG'];
 
 interface StepCollectProps {
-  complaintId: string | undefined;
+  complaintId: string;
 }
 
 export function StepCollect({ complaintId }: StepCollectProps) {

--- a/src/app/my-space/case/components/StepCollect.tsx
+++ b/src/app/my-space/case/components/StepCollect.tsx
@@ -1,4 +1,11 @@
+'use client';
+
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { EvidenceCard } from './evidence/EvidenceCard';
+import { EvidenceCardErrorFallback } from '@/components/fallbacks/EvidenceCardErrorFallback';
+import { EvidenceCardSkeleton } from '@/components/skeletons/EvidenceCardSkeleton';
 import type { EvidenceType } from '@/types/evidence';
 
 /** 왼쪽: 이미지 프리뷰 카드 */
@@ -17,14 +24,30 @@ export function StepCollect({ complaintId }: StepCollectProps) {
       {/* 왼쪽 컬럼 — 이미지 프리뷰 */}
       <div className="flex flex-1 flex-col gap-6">
         {LEFT_TYPES.map((type) => (
-          <EvidenceCard key={type} type={type} complaintId={complaintId} />
+          <QueryErrorResetBoundary key={type}>
+            {({ reset }) => (
+              <ErrorBoundary FallbackComponent={EvidenceCardErrorFallback} onReset={reset}>
+                <Suspense fallback={<EvidenceCardSkeleton />}>
+                  <EvidenceCard type={type} complaintId={complaintId} />
+                </Suspense>
+              </ErrorBoundary>
+            )}
+          </QueryErrorResetBoundary>
         ))}
       </div>
 
       {/* 오른쪽 컬럼 — 파일 프리뷰 */}
       <div className="flex flex-1 flex-col gap-6">
         {RIGHT_TYPES.map((type) => (
-          <EvidenceCard key={type} type={type} complaintId={complaintId} />
+          <QueryErrorResetBoundary key={type}>
+            {({ reset }) => (
+              <ErrorBoundary FallbackComponent={EvidenceCardErrorFallback} onReset={reset}>
+                <Suspense fallback={<EvidenceCardSkeleton />}>
+                  <EvidenceCard type={type} complaintId={complaintId} />
+                </Suspense>
+              </ErrorBoundary>
+            )}
+          </QueryErrorResetBoundary>
         ))}
       </div>
     </div>

--- a/src/app/my-space/case/components/evidence/EvidenceCard.tsx
+++ b/src/app/my-space/case/components/evidence/EvidenceCard.tsx
@@ -18,7 +18,7 @@ interface EvidenceCardProps {
   /** 증거 타입 (MESSAGE, VOICE 등) */
   type: EvidenceType;
   /** 고소장 ID (React Query 훅에 전달) */
-  complaintId: string | undefined;
+  complaintId: string;
   /** 외부에서 전달하는 추가 스타일 */
   className?: string;
 }

--- a/src/app/my-space/case/components/evidence/ImagePreview.tsx
+++ b/src/app/my-space/case/components/evidence/ImagePreview.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import TrashOutlineIcon from '@/assets/icons/TrashOutlineIcon.svg';
 import imageFallback from '@/assets/image-fallback.png';
+import { Skeleton } from '@/components/ui/skeleton';
 
 type PreviewSize = 'sm' | 'md' | 'lg' | 'fill';
 
@@ -67,19 +68,23 @@ export function ImagePreview({
   const imgAlt = file?.name ?? alt ?? '';
   /** 이미지 로드 실패 시 fallback 이미지 표시용 */
   const [hasError, setHasError] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
 
   return (
     <div
-      className={`group relative shrink-0 overflow-hidden rounded-lg border border-white bg-gray-100 ${sizeStyles[size]}`}
+      className={`group relative shrink-0 overflow-hidden rounded-lg border border-white ${sizeStyles[size]}`}
     >
+      {!isLoaded && <Skeleton className="absolute inset-0 rounded-lg" />}
       <Image
         src={hasError ? imageFallback : imgSrc}
         alt={imgAlt}
         fill
         sizes="(max-width: 768px) 25vw, 152px"
         className="object-cover"
+        onLoad={() => setIsLoaded(true)}
         onError={() => {
           if (!hasError) setHasError(true);
+          setIsLoaded(true);
         }}
         unoptimized={!!blobSrc}
       />

--- a/src/app/my-space/case/hooks/useComplaint.ts
+++ b/src/app/my-space/case/hooks/useComplaint.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getComplaint, updateComplaint } from '@/api/complaint';
 import type { UpdateComplaintPayload } from '@/types/complaint';
 
@@ -11,11 +11,10 @@ import type { UpdateComplaintPayload } from '@/types/complaint';
  *
  * @param complaintId - 고소장 ID (undefined이면 요청하지 않음)
  */
-export function useComplaint(complaintId: string | undefined) {
-  return useQuery({
+export function useComplaint(complaintId: string) {
+  return useSuspenseQuery({
     queryKey: ['complaint', complaintId],
-    queryFn: () => getComplaint(complaintId!),
-    enabled: !!complaintId,
+    queryFn: () => getComplaint(complaintId),
     staleTime: 1000 * 60 * 5, // 5분간 캐시 유지
   });
 }

--- a/src/app/my-space/case/hooks/useEvidence.ts
+++ b/src/app/my-space/case/hooks/useEvidence.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getPresignedUrls,
   uploadToS3,
@@ -164,11 +164,10 @@ const registerByType = async (
  * @param type - 증거 타입 (MESSAGE, VOICE, VICTIM, REPORT_RECORD, INCIDENT_LOG)
  * @returns `{ items: EvidencePreviewItem[], totalCount: number }`
  */
-export function useEvidencePreviews(complaintId: string | undefined, type: EvidenceType) {
-  return useQuery({
-    queryKey: evidenceKeys.previews(complaintId!, type),
-    queryFn: () => fetchAndNormalize[type](complaintId!),
-    enabled: !!complaintId,
+export function useEvidencePreviews(complaintId: string, type: EvidenceType) {
+  return useSuspenseQuery({
+    queryKey: evidenceKeys.previews(complaintId, type),
+    queryFn: () => fetchAndNormalize[type](complaintId),
     staleTime: 1000 * 60 * 5, // 5분간 캐시 유지 (불필요한 refetch 방지)
   });
 }

--- a/src/app/my-space/case/hooks/useEvidenceCard.ts
+++ b/src/app/my-space/case/hooks/useEvidenceCard.ts
@@ -12,7 +12,7 @@ import type { EvidenceType } from '@/types/evidence';
  * - 파일 업로드/삭제 핸들러
  * - 삭제 확인 모달 상태
  */
-export function useEvidenceCard(complaintId: string | undefined, type: EvidenceType) {
+export function useEvidenceCard(complaintId: string, type: EvidenceType) {
   const config = EVIDENCE_CONFIG[type];
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -28,8 +28,8 @@ export function useEvidenceCard(complaintId: string | undefined, type: EvidenceT
   const upload = useUploadEvidence(complaintId, type);
   const remove = useDeleteEvidence(complaintId, type);
 
-  const items = data?.items ?? [];
-  const totalCount = data?.totalCount ?? 0;
+  const items = data.items;
+  const totalCount = data.totalCount;
   const isFull = totalCount >= config.maxFiles;
 
   /** 파일 추가 — 중복 검사 → 프론트 검증 → 업로드 mutation 호출 */

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -53,8 +53,10 @@ export default function CasePage() {
  */
 function CasePageContent() {
   const user = useAuthStore((s) => s.user);
-  const { data: complaint } = useComplaint(user!.complaint_id);
-  const { mutate: save, isPending: isSaving } = useUpdateComplaint(user!.complaint_id);
+  const { data: complaint } = useComplaint(user?.complaint_id ?? '');
+  const { mutate: save, isPending: isSaving } = useUpdateComplaint(user?.complaint_id ?? '');
+
+  if (!user) return null;
 
   // 서버 데이터 → 프론트 step 변환
   const step: Step = STEP_MAP[complaint.step];
@@ -101,7 +103,7 @@ function CasePageContent() {
         {/* 4단계 프로그레스 바 */}
         <CaseProgress currentStep={step} />
         {/* 스텝별 컨텐츠 조건부 렌더링 */}
-        {step === 1 && <StepCollect complaintId={user!.complaint_id} />}
+        {step === 1 && <StepCollect complaintId={user.complaint_id} />}
         {step === 2 && <StepTimeline />}
         {step === 3 && <StepDocument />}
         {step === 4 && <StepComplete />}

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useAuthStore } from '@/stores/authStore';
 import { useComplaint, useUpdateComplaint } from './hooks/useComplaint';
 import { STEP_MAP, STEP_REVERSE_MAP, type Step } from '@/types/complaint';
@@ -11,6 +13,9 @@ import {
   StepDocument,
   StepComplete,
 } from './components';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { CaseErrorFallback } from '@/components/fallbacks/CaseErrorFallback';
+import { CasePageSkeleton } from '@/components/skeletons/CasePageSkeleton';
 
 const MIN_STEP: Step = 1;
 const MAX_STEP: Step = 4;
@@ -24,18 +29,36 @@ const clampStep = (n: number): Step => {
 
 /**
  * Case 퍼널 진입점
+ * - ErrorBoundary + Suspense로 로딩/에러 처리
+ */
+export default function CasePage() {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary FallbackComponent={CaseErrorFallback} onReset={reset}>
+          <Suspense fallback={<CasePageSkeleton />}>
+            <CasePageContent />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  );
+}
+
+/**
+ * Case 퍼널 컨텐츠
  * - 하나의 페이지에서 step 상태로 4단계를 전환하는 퍼널 패턴
  * - 헤더(제목·저장·이전/다음) + 프로그레스 바 + 스텝별 컨텐츠로 구성
  * - 이전/다음 버튼 → step 변경 → 헤더·프로그레스·컨텐츠 동기화
  */
-export default function CasePage() {
+function CasePageContent() {
   const user = useAuthStore((s) => s.user);
   const { data: complaint } = useComplaint(user!.complaint_id);
   const { mutate: save, isPending: isSaving } = useUpdateComplaint(user!.complaint_id);
 
   // 서버 데이터 → 프론트 step 변환
-  const step: Step = complaint ? STEP_MAP[complaint.step] : 1;
-  const title = complaint?.name ?? '사건 제목';
+  const step: Step = STEP_MAP[complaint.step];
+  const title = complaint.name;
 
   /** 다음 스텝으로 이동 + 서버 저장 */
   const goNext = () => {
@@ -72,7 +95,7 @@ export default function CasePage() {
         onNext={goNext}
         hasPrev={step > MIN_STEP}
         hasNext={step < MAX_STEP}
-        updatedAt={complaint?.updated_at ?? ''}
+        updatedAt={complaint.updated_at}
       />
       <div className="space-y-6 p-6">
         {/* 4단계 프로그레스 바 */}

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -31,7 +31,7 @@ const clampStep = (n: number): Step => {
 export default function CasePage() {
   const user = useAuthStore((s) => s.user);
   const { data: complaint } = useComplaint(user!.complaint_id);
-  const { mutate: save, isPending: isSaving } = useUpdateComplaint(user?.complaint_id);
+  const { mutate: save, isPending: isSaving } = useUpdateComplaint(user!.complaint_id);
 
   // 서버 데이터 → 프론트 step 변환
   const step: Step = complaint ? STEP_MAP[complaint.step] : 1;
@@ -59,8 +59,6 @@ export default function CasePage() {
     save({ name: title, step: STEP_REVERSE_MAP[step] });
   };
 
-  if (isLoading) return <div className="p-6">로딩 중...</div>;
-
   return (
     <div>
       {/* 상단 헤더: 제목 편집 + 저장 + 이전/다음 버튼 */}
@@ -80,7 +78,7 @@ export default function CasePage() {
         {/* 4단계 프로그레스 바 */}
         <CaseProgress currentStep={step} />
         {/* 스텝별 컨텐츠 조건부 렌더링 */}
-        {step === 1 && <StepCollect complaintId={user?.complaint_id} />}
+        {step === 1 && <StepCollect complaintId={user!.complaint_id} />}
         {step === 2 && <StepTimeline />}
         {step === 3 && <StepDocument />}
         {step === 4 && <StepComplete />}

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -37,12 +37,19 @@ export default function CasePage() {
       {({ reset }) => (
         <ErrorBoundary FallbackComponent={CaseErrorFallback} onReset={reset}>
           <Suspense fallback={<CasePageSkeleton />}>
-            <CasePageContent />
+            <CasePageGuard />
           </Suspense>
         </ErrorBoundary>
       )}
     </QueryErrorResetBoundary>
   );
+}
+
+/** complaintId 존재 확인 후 CasePageContent 렌더 */
+function CasePageGuard() {
+  const user = useAuthStore((s) => s.user);
+  if (!user?.complaint_id) return null;
+  return <CasePageContent complaintId={user.complaint_id} />;
 }
 
 /**
@@ -51,12 +58,9 @@ export default function CasePage() {
  * - 헤더(제목·저장·이전/다음) + 프로그레스 바 + 스텝별 컨텐츠로 구성
  * - 이전/다음 버튼 → step 변경 → 헤더·프로그레스·컨텐츠 동기화
  */
-function CasePageContent() {
-  const user = useAuthStore((s) => s.user);
-  const { data: complaint } = useComplaint(user?.complaint_id ?? '');
-  const { mutate: save, isPending: isSaving } = useUpdateComplaint(user?.complaint_id ?? '');
-
-  if (!user) return null;
+function CasePageContent({ complaintId }: { complaintId: string }) {
+  const { data: complaint } = useComplaint(complaintId);
+  const { mutate: save, isPending: isSaving } = useUpdateComplaint(complaintId);
 
   // 서버 데이터 → 프론트 step 변환
   const step: Step = STEP_MAP[complaint.step];
@@ -103,7 +107,7 @@ function CasePageContent() {
         {/* 4단계 프로그레스 바 */}
         <CaseProgress currentStep={step} />
         {/* 스텝별 컨텐츠 조건부 렌더링 */}
-        {step === 1 && <StepCollect complaintId={user.complaint_id} />}
+        {step === 1 && <StepCollect complaintId={complaintId} />}
         {step === 2 && <StepTimeline />}
         {step === 3 && <StepDocument />}
         {step === 4 && <StepComplete />}

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -30,7 +30,7 @@ const clampStep = (n: number): Step => {
  */
 export default function CasePage() {
   const user = useAuthStore((s) => s.user);
-  const { data: complaint, isLoading } = useComplaint(user?.complaint_id);
+  const { data: complaint } = useComplaint(user!.complaint_id);
   const { mutate: save, isPending: isSaving } = useUpdateComplaint(user?.complaint_id);
 
   // 서버 데이터 → 프론트 step 변환

--- a/src/components/MySpaceSidebar.tsx
+++ b/src/components/MySpaceSidebar.tsx
@@ -7,6 +7,7 @@ import ProfileIcon from '@/assets/icons/profile-defalt.svg';
 
 import { useAuthStore } from '@/stores/authStore';
 import { Button } from '@/components/Button';
+import { Skeleton } from '@/components/ui/skeleton';
 import stalkingDefault from '@/assets/icons/stalking-default.png';
 import stalkingActive from '@/assets/icons/stalking-active.png';
 import evidenceDefault from '@/assets/icons/evidence-default.png';
@@ -162,7 +163,15 @@ export function MySpaceSidebar() {
               <div className="flex items-center gap-2 px-1 py-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:px-0">
                 <ProfileIcon className="size-5 shrink-0" />
                 <span className="typo-body-3 text-gray-600 transition-opacity delay-150 duration-300 group-data-[collapsible=icon]:w-0 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-0">
-                  {isLoggedIn ? `${user?.name ?? '...'}님` : 'Guest'}
+                  {isLoggedIn ? (
+                    user?.name ? (
+                      `${user.name}님`
+                    ) : (
+                      <Skeleton className="h-4 w-16" />
+                    )
+                  ) : (
+                    'Guest'
+                  )}
                 </span>
               </div>
             </SidebarMenuButton>

--- a/src/components/fallbacks/CaseErrorFallback.tsx
+++ b/src/components/fallbacks/CaseErrorFallback.tsx
@@ -1,0 +1,12 @@
+import type { FallbackProps } from 'react-error-boundary';
+
+export function CaseErrorFallback({ resetErrorBoundary }: FallbackProps) {
+  return (
+    <div className="flex flex-col items-center gap-3 p-6">
+      <p className="typo-body-8 text-gray-500">사건 정보를 불러오지 못했어요.</p>
+      <button onClick={resetErrorBoundary} className="typo-btn-2 text-blue-500 underline">
+        다시 시도
+      </button>
+    </div>
+  );
+}

--- a/src/components/fallbacks/EvidenceCardErrorFallback.tsx
+++ b/src/components/fallbacks/EvidenceCardErrorFallback.tsx
@@ -1,0 +1,12 @@
+import type { FallbackProps } from 'react-error-boundary';
+
+export function EvidenceCardErrorFallback({ resetErrorBoundary }: FallbackProps) {
+  return (
+    <div className="flex min-h-40 flex-col items-center justify-center gap-3 rounded-2xl border border-gray-200 px-7 py-6 shadow-[0px_20px_50px_-5px_#4040400D]">
+      <p className="typo-body-8 text-gray-500">증거 데이터를 불러오지 못했어요.</p>
+      <button onClick={resetErrorBoundary} className="typo-btn-2 text-blue-500 underline">
+        다시 시도
+      </button>
+    </div>
+  );
+}

--- a/src/components/providers/QueryClientProvider.tsx
+++ b/src/components/providers/QueryClientProvider.tsx
@@ -4,6 +4,15 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState, type ReactNode } from 'react';
 
 export function QueryProvider({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            throwOnError: true,
+          },
+        },
+      }),
+  );
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }

--- a/src/components/skeletons/CasePageSkeleton.tsx
+++ b/src/components/skeletons/CasePageSkeleton.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function CasePageSkeleton() {
+  return (
+    <div>
+      {/* CaseHeader */}
+      <div className="flex w-full justify-between border-b border-gray-100 p-6">
+        <div className="flex flex-col gap-1">
+          <Skeleton className="h-7 w-48" />
+          <Skeleton className="h-4 w-32" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-10 w-14" />
+          <Skeleton className="h-10 w-14" />
+          <Skeleton className="h-10 w-24" />
+        </div>
+      </div>
+      {/* CaseProgress + 컨텐츠 */}
+      <div className="space-y-6 p-6">
+        <Skeleton className="h-2 w-full rounded-full" />
+        <Skeleton className="h-64 w-full rounded-2xl" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/skeletons/CasePageSkeleton.tsx
+++ b/src/components/skeletons/CasePageSkeleton.tsx
@@ -17,8 +17,18 @@ export function CasePageSkeleton() {
       </div>
       {/* CaseProgress + 컨텐츠 */}
       <div className="space-y-6 p-6">
-        <Skeleton className="h-2 w-full rounded-full" />
-        <Skeleton className="h-64 w-full rounded-2xl" />
+        {/* CaseProgress: 4개 스텝 + dash 연결선 */}
+        <div className="flex items-center gap-6 px-12 py-3">
+          {[1, 2, 3, 4].map((step, index) => (
+            <div key={step} className="contents">
+              {index > 0 && <div className="h-px flex-1 bg-gray-200" />}
+              <div className="flex w-30 flex-col items-center gap-1">
+                <Skeleton className="h-4 w-14" />
+                <Skeleton className="h-6 w-20" />
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/skeletons/EvidenceCardSkeleton.tsx
+++ b/src/components/skeletons/EvidenceCardSkeleton.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function EvidenceCardSkeleton() {
+  return (
+    <div className="flex min-h-40 flex-col gap-6 rounded-2xl border border-gray-200 px-7 py-6 shadow-[0px_20px_50px_-5px_#4040400D]">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-10 w-10 rounded-full" />
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-3 w-40" />
+        </div>
+      </div>
+      {/* Content */}
+      <Skeleton className="h-24 w-full rounded-xl" />
+      {/* Footer */}
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-6 w-16 rounded-full" />
+        <Skeleton className="h-10 w-28 rounded-lg" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils';
 
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('bg-primary/10 animate-pulse rounded-md', className)} {...props} />;
+  return <div className={cn('animate-pulse rounded-md bg-gray-100', className)} {...props} />;
 }
 
 export { Skeleton };


### PR DESCRIPTION
## 작업 내용

React Query 기반 데이터 페칭 구조를 Suspense + ErrorBoundary 패턴으로 리팩토링했습니다.

---

### 문제

기존에는 각 컴포넌트에서 다음을 반복적으로 처리했습니다.

- `isLoading`, `isError` 분기
- `data | undefined` 타입 처리 (`data!`, `?? []`)
- 로딩 / 에러 / UI 책임이 하나의 컴포넌트에 혼재

```tsx
// 기존 패턴
const { data, isLoading, isError, refetch } = useQuery(...)

if (isLoading) return <Skeleton />
if (isError) return <ErrorUI onRetry={refetch} />

return <UI data={data!} />
````

컴포넌트가 "데이터를 어떻게 보여줄 것인가"와 "데이터가 없을 때 무엇을 보여줄 것인가"를 동시에 담당하게 되어
코드 중복, 가독성 저하, 관심사 분리 실패로 이어졌습니다.

---

### 해결

#### 1. Suspense 도입

`useSuspenseQuery`를 적용하여 로딩 상태를 컴포넌트 외부로 분리했습니다.

* 로딩 중 → Promise throw → `<Suspense fallback>`에서 처리
* 컴포넌트는 항상 데이터가 존재하는 시점에만 렌더

```tsx
// 변경 후
const { data } = useSuspenseQuery(...)
return <UI data={data} />
```

효과:

* `isLoading` 분기 제거
* `data: T | undefined → T` 타입 안정성 확보
* `data!`, `data?.items ?? []` 등의 방어 코드 제거

---

#### 2. ErrorBoundary 도입

에러 발생 시 throw → `<ErrorBoundary>`에서 처리하도록 변경했습니다.

* `react-error-boundary`의 `FallbackComponent` 사용
* fallback에서 `error`, `resetErrorBoundary`를 받아 재시도 처리

효과:

* 컴포넌트 내부 `isError` 분기 제거
* 에러 UI 중앙화 및 재사용 구조 확보
* 페이지 / 카드 단위로 서로 다른 에러 UI 적용 가능

---

#### 3. 경계 분리 설계

페이지 단위와 카드 단위로 경계를 분리하여 장애를 격리했습니다.

```
CasePage
└── QueryErrorResetBoundary
    └── ErrorBoundary (CaseErrorFallback)
        └── Suspense (CasePageSkeleton)
            └── CasePageGuard
                └── CasePageContent

StepCollect (카드 단위)
└── QueryErrorResetBoundary
    └── ErrorBoundary (EvidenceCardErrorFallback)
        └── Suspense (EvidenceCardSkeleton)
            └── EvidenceCard
```

효과:

* 일부 카드 실패 시 전체 UI 영향 방지
* 카드별 독립적인 로딩 / 에러 / 재시도 UX 제공

---

#### 4. QueryErrorResetBoundary 적용

문제:

* ErrorBoundary만 reset하면 React Query 캐시는 여전히 에러 상태 유지
* 재요청이 정상적으로 동작하지 않음

해결:

* `QueryErrorResetBoundary`의 `reset`을 ErrorBoundary `onReset`에 연결

```tsx
<QueryErrorResetBoundary>
  {({ reset }) => (
    <ErrorBoundary FallbackComponent={CaseErrorFallback} onReset={reset}>
      ...
    </ErrorBoundary>
  )}
</QueryErrorResetBoundary>
```

효과:

* ErrorBoundary 상태 + Query 캐시 동시 리셋
* `queryClient.resetQueries()` 사용 시 발생하는 전역 부작용 방지

---

#### 5. Guard 패턴으로 초기 요청 문제 해결

문제:

* `useSuspenseQuery`는 `enabled`, `skipToken` 미지원
* `complaint_id` 없는 상태에서 API 요청 발생

```
GET /complaints/my-complaint?complaint_id=
422 (Unprocessable Content)
```

해결:

* Guard 컴포넌트를 통해 유효한 값이 있을 때만 렌더

```tsx
function CasePageGuard() {
  const user = useAuthStore((s) => s.user);
  if (!user?.complaint_id) return null;
  return <CasePageContent complaintId={user.complaint_id} />;
}

function CasePageContent({ complaintId }: { complaintId: string }) {
  const { data } = useComplaint(complaintId);
  ...
}
```

효과:

* 잘못된 API 요청 차단
* `complaintId`를 항상 string으로 보장

---

### 결과

* 데이터 페칭 컴포넌트 코드 약 30~40% 감소
* 로딩 / 에러 처리 로직 완전 분리
* 타입 안정성 확보 (`undefined 제거`)
* UI 독립성 강화 (카드 단위 부분 실패 허용)

---

### 추가 개선

* `QueryClient`에 `throwOnError: true` 전역 설정 → 일관된 에러 전파
* Skeleton UI 컬러 통일 (`bg-primary/10 → bg-gray-100`)
* ImagePreview: 이미지 로딩 중 Skeleton 적용
* MySpaceSidebar: 유저 이름 로딩 상태 Skeleton 처리

---

### 이슈 번호
#47 

---

### 스크린샷 (선택)


https://github.com/user-attachments/assets/bb52072b-5ef3-4ab6-a4d5-695f88b2bff9


