### PR TITLE
[FEAT][#51]: step2 타임라인 백엔드 api 연결 및 에러바운더리 수정

### DIFF
--- a/src/api/timeline.ts
+++ b/src/api/timeline.ts
@@ -1,0 +1,125 @@
+import { axiosInstance } from './axiosInstance';
+import type {
+  TimelineResponse,
+  TimelineEvidenceDetail,
+  TimelineFormDataRequest,
+  TimelineFormDataResponse,
+  ManualReferencedEvidencePresignedUrlRequest,
+  ManualReferencedEvidencePresignedUrlResponse,
+  ManualReferencedEvidenceRegisterRequest,
+  ManualReferencedEvidenceRegisterResponse,
+  DeleteTimelineEvidencesRequest,
+  DeleteManualReferencedEvidencesRequest,
+  TimelineDownloadResponse,
+} from '@/types/timeline';
+
+// ─── 타임라인 조회 ────────────────────────────────────────
+
+/** 날짜 > 시각 > 증거 계층 구조의 타임라인 조회 */
+export async function getTimeline(complaintId: string, generateDummy?: boolean) {
+  const res = await axiosInstance.get<TimelineResponse>(`/api/v1/${complaintId}/timeline`, {
+    params: generateDummy ? { generate_dummy: true } : undefined,
+  });
+  return res.data;
+}
+
+// ─── 타임라인 증거 상세 ───────────────────────────────────
+
+/** 증거 메타데이터(날짜, 시각, 제목, 설명, 태그)와 참조 증거 목록 조회 */
+export async function getTimelineEvidenceDetail(complaintId: string, timelineEvidenceId: string) {
+  const res = await axiosInstance.get<TimelineEvidenceDetail>(
+    `/api/v1/${complaintId}/timeline/evidences/${timelineEvidenceId}`,
+  );
+  return res.data;
+}
+
+// ─── 타임라인 증거 수정 ───────────────────────────────────
+
+/** 타임라인 증거의 폼 데이터(날짜, 시각, 제목, 설명, 태그) 수정 */
+export async function updateTimelineEvidenceFormData(
+  complaintId: string,
+  timelineEvidenceId: string,
+  payload: TimelineFormDataRequest,
+) {
+  const res = await axiosInstance.patch<TimelineFormDataResponse>(
+    `/api/v1/${complaintId}/timeline/evidences/${timelineEvidenceId}/form-data`,
+    payload,
+  );
+  return res.data;
+}
+
+// ─── 타임라인 증거 삭제 ───────────────────────────────────
+
+/** 타임라인 증거 복수 삭제 */
+export async function deleteTimelineEvidences(
+  complaintId: string,
+  payload: DeleteTimelineEvidencesRequest,
+) {
+  await axiosInstance.delete(`/api/v1/${complaintId}/timeline/evidences`, {
+    data: payload,
+  });
+}
+
+// ─── 직접 추가 증거 ───────────────────────────────────────
+
+/** 직접 추가 증거의 폼 데이터 업로드 */
+export async function createManualTimelineEvidence(
+  complaintId: string,
+  payload: TimelineFormDataRequest,
+) {
+  const res = await axiosInstance.post<TimelineFormDataResponse>(
+    `/api/v1/${complaintId}/timeline/evidences/manual/form-data`,
+    payload,
+  );
+  return res.data;
+}
+
+// ─── 직접 추가 증거 — 참조 증거 ──────────────────────────
+
+/** 참조 증거 Presigned URL 발급 (복수 지원) */
+export async function getManualReferencedEvidencePresignedUrls(
+  complaintId: string,
+  timelineEvidenceId: string,
+  payload: ManualReferencedEvidencePresignedUrlRequest,
+) {
+  const res = await axiosInstance.post<ManualReferencedEvidencePresignedUrlResponse>(
+    `/api/v1/${complaintId}/timeline/evidences/${timelineEvidenceId}/manual/referenced-evidences/presigned-url`,
+    payload,
+  );
+  return res.data;
+}
+
+/** S3 업로드 완료 후 참조 증거 등록 (복수 지원) */
+export async function registerManualReferencedEvidences(
+  complaintId: string,
+  timelineEvidenceId: string,
+  payload: ManualReferencedEvidenceRegisterRequest,
+) {
+  const res = await axiosInstance.post<ManualReferencedEvidenceRegisterResponse>(
+    `/api/v1/${complaintId}/timeline/evidences/${timelineEvidenceId}/manual/referenced-evidences/register`,
+    payload,
+  );
+  return res.data;
+}
+
+/** 참조 증거 삭제 (복수 지원) */
+export async function deleteManualReferencedEvidences(
+  complaintId: string,
+  timelineEvidenceId: string,
+  payload: DeleteManualReferencedEvidencesRequest,
+) {
+  await axiosInstance.delete(
+    `/api/v1/${complaintId}/timeline/evidences/${timelineEvidenceId}/manual/referenced-evidences`,
+    { data: payload },
+  );
+}
+
+// ─── 다운로드 ────────────────────────────────────────────
+
+/** ZIP 다운로드용 presigned URL 발급 */
+export async function downloadTimelineZip(complaintId: string) {
+  const res = await axiosInstance.post<TimelineDownloadResponse>(
+    `/api/v1/${complaintId}/timeline/download/zip`,
+  );
+  return res.data;
+}

--- a/src/app/my-space/case/components/StepTimeline.tsx
+++ b/src/app/my-space/case/components/StepTimeline.tsx
@@ -5,24 +5,27 @@ import FileDownloadIcon from '@/assets/icons/FileDownloadIcon.svg';
 import { Button } from '@/components/Button';
 import { TabsList } from '@/components/ui/tabs';
 import { AppTabs, AppTabsTrigger, AppTabsContent } from '@/components/AppTabs';
-import { useTimeline } from '../hooks/useTimeline';
+import { useTimeline, useDownloadTimeline } from '../hooks/useTimeline';
 import { TimelineView } from './timeline/TimelineView';
 import { ByDateView } from './timeline/ByDateView';
 import { ByTypeView } from './timeline/ByTypeView';
 import { EvidenceDownloadModal } from './timeline/EvidenceDownloadModal';
-
-interface StepTimelineProps {
-  complaintId: string;
-}
 
 /**
  * 타임라인 정리 단계 (Step 2)
  * - 타임라인 보기 / 날짜별 보기 / 종류별 보기 탭
  * - 다운로드 버튼
  */
-export function StepTimeline({ complaintId }: StepTimelineProps) {
-  const { groups, allDates, allTags } = useTimeline(complaintId);
+export function StepTimeline() {
+  const { groups, allDates, allTags } = useTimeline();
+  const downloadTimeline = useDownloadTimeline();
   const [downloadOpen, setDownloadOpen] = useState(false);
+
+  const handleDownload = async () => {
+    const { download_url } = await downloadTimeline.mutateAsync();
+    window.open(download_url, '_blank');
+    setDownloadOpen(false);
+  };
 
   return (
     <>
@@ -57,7 +60,15 @@ export function StepTimeline({ complaintId }: StepTimelineProps) {
         </AppTabsContent>
       </AppTabs>
 
-      <EvidenceDownloadModal open={downloadOpen} onOpenChange={setDownloadOpen} />
+      <EvidenceDownloadModal
+        open={downloadOpen}
+        onOpenChange={setDownloadOpen}
+        title="타임라인 다운로드"
+        subTitle="타임라인으로 정리된 증거 자료 ZIP 파일입니다"
+        fileName="안심은_증거분석타임라인.zip"
+        onDownload={handleDownload}
+        isDownloading={downloadTimeline.isPending}
+      />
     </>
   );
 }

--- a/src/app/my-space/case/components/timeline/EvidenceDownloadModal.tsx
+++ b/src/app/my-space/case/components/timeline/EvidenceDownloadModal.tsx
@@ -4,35 +4,41 @@ import FileIcon from '@/assets/icons/FileIcon.svg';
 import FileDownloadIcon from '@/assets/icons/FileDownloadIcon.svg';
 import { Button } from '@/components/Button';
 import { Modal } from '@/components/modals/Modal';
+import { Spinner } from '@/components/Spinner';
 
 interface EvidenceDownloadModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  title?: string;
+  subTitle?: string;
   /** 파일명 (없으면 기본 파일명 표시) */
   fileName?: string;
   /** 파일 용량 (예: "48.0MB") */
   fileSize?: string;
+  /** 다운로드 버튼 클릭 핸들러 */
+  onDownload?: () => void;
+  /** 다운로드 중 여부 */
+  isDownloading?: boolean;
 }
 
-/** 증거 자료 다운로드 확인 모달 */
+/** 다운로드 확인 모달 */
 export function EvidenceDownloadModal({
   open,
   onOpenChange,
+  title = '증거 자료 다운로드',
+  subTitle = '타임라인으로 정리된 증거 자료 PDF 파일입니다',
   fileName = '안심은_증거분석타임라인.zip',
   fileSize,
+  onDownload,
+  isDownloading = false,
 }: EvidenceDownloadModalProps) {
   const handleDownload = () => {
-    // TODO: API 연결
-    console.log('download', fileName);
-    onOpenChange(false);
+    onDownload?.();
   };
 
   return (
     <Modal.Root open={open} onOpenChange={onOpenChange} className="w-110">
-      <Modal.Header
-        title="증거 자료 다운로드"
-        subTitle="타임라인으로 정리된 증거 자료 PDF 파일입니다"
-      />
+      <Modal.Header title={title} subTitle={subTitle} />
       <Modal.Body className="flex flex-col gap-2">
         <p className="typo-body-8 text-gray-400">최종 파일</p>
         <div className="flex items-center gap-3 rounded-lg border border-gray-100 bg-gray-50 p-3">
@@ -42,9 +48,13 @@ export function EvidenceDownloadModal({
         </div>
       </Modal.Body>
       <Modal.Footer direction="col" full>
-        <Button color="contrast" size="xl" onClick={handleDownload}>
-          <FileDownloadIcon width={18} height={18} className="text-white" />
-          다운로드
+        <Button color="contrast" size="xl" onClick={handleDownload} disabled={isDownloading}>
+          {isDownloading ? (
+            <Spinner size="sm" className="text-white" />
+          ) : (
+            <FileDownloadIcon width={18} height={18} className="text-white" />
+          )}
+          {isDownloading ? '다운로드 중...' : '다운로드'}
         </Button>
       </Modal.Footer>
     </Modal.Root>

--- a/src/app/my-space/case/components/timeline/TimelineFormModal.tsx
+++ b/src/app/my-space/case/components/timeline/TimelineFormModal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { Button } from '@/components/Button';
 import { Input } from '@/components/Input';
 import { Modal } from '@/components/modals/Modal';
+import { Spinner } from '@/components/Spinner';
 import { EvidenceContent } from '../evidence/EvidenceContent';
-import type { EvidencePreviewItem } from '@/types/evidence';
 import {
   TAG_LABEL_MAP,
   TAG_COLOR_MAP,
@@ -14,8 +14,16 @@ import {
 } from '@/types/timeline';
 import { TAG_ICON } from './TimelineTagBadge';
 import { useTimelineForm } from '../../hooks/useTimelineForm';
+import { useTimelineFiles } from '../../hooks/useTimelineFiles';
+import { useTimelineSubmit } from '../../hooks/useTimelineSubmit';
 
-const ALL_TAGS: TimelineTag[] = ['PHYSICAL_HARM', 'THREAT', 'SEXUAL_INSULT', 'REFUSAL', 'REPEAT'];
+const ALL_TAGS: TimelineTag[] = [
+  'PHYSICAL_HARM',
+  'THREAT_COERCION',
+  'SEXUAL_INSULT',
+  'REFUSAL_INTENT',
+  'REPEAT',
+];
 
 interface TimelineFormModalProps {
   open: boolean;
@@ -37,40 +45,41 @@ export function TimelineFormModal({
   initialTime = '',
   evidence,
 }: TimelineFormModalProps) {
-  const {
-    date,
-    setDate,
-    time,
-    handleTimeChange,
-    handleTimeBlur,
-    title,
-    setTitle,
-    description,
-    setDescription,
-    selectedTags,
-    toggleTag,
-  } = useTimelineForm({ initialDate, initialTime, evidence });
-
-  // TODO: API 연결 시 filterValidFiles로 타입·크기·길이·개수 검증 추가, rejected 파일은 toast.error()로 표시
-  const [files, setFiles] = useState<EvidencePreviewItem[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const canEditFiles = !evidence?.is_ai_original;
 
-  const handleFilesAdd = (newFiles: File[]) => {
-    const items: EvidencePreviewItem[] = newFiles.map((f) => ({
-      id: `${f.name}-${f.size}`,
-      filename: f.name,
-      sizeBytes: f.size,
-    }));
-    setFiles((prev) => [...prev, ...items]);
-  };
+  const files = useTimelineFiles({
+    open,
+    isEditMode: mode === 'edit',
+    canEditFiles,
+    evidence,
+  });
 
-  const handleFileRemove = (id: string) => setFiles((prev) => prev.filter((f) => f.id !== id));
+  const formHook = useTimelineForm({ open, initialDate, initialTime, evidence });
 
-  const handleSubmit = () => {
-    // TODO: API 연결
-    console.log({ date, time, title, description, tags: selectedTags, files });
-    onOpenChange(false);
-  };
+  const { submit, isSubmitting } = useTimelineSubmit({
+    mode,
+    canEditFiles,
+    evidence,
+    onClose: () => onOpenChange(false),
+  });
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = formHook.form;
+  const descriptionValue = watch('description');
+
+  const handleFormSubmit = handleSubmit(async (values) => {
+    await submit({
+      formValues: values,
+      tags: formHook.selectedTags,
+      uploadFiles: files.getUploadFiles(),
+      deleteIds: files.getDeleteIds(),
+    });
+  });
 
   return (
     <Modal.Root open={open} onOpenChange={onOpenChange} className="max-h-[90vh] w-135 flex-col">
@@ -86,16 +95,18 @@ export function TimelineFormModal({
             label="날짜"
             required
             type="date"
-            value={date}
-            onChange={(e) => setDate(e.target.value)}
+            {...register('date')}
+            error={errors.date?.message}
           />
           <Input
             label="시간"
             required
             placeholder="00:00"
-            value={time}
-            onChange={(e) => handleTimeChange(e.target.value)}
-            onBlur={handleTimeBlur}
+            {...register('time', {
+              onChange: (e) => formHook.handleTimeChange(e.target.value),
+            })}
+            onBlur={formHook.handleTimeBlur}
+            error={errors.time?.message}
           />
         </div>
 
@@ -104,21 +115,22 @@ export function TimelineFormModal({
           label="제목"
           required
           placeholder="제목을 입력해주세요"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
+          {...register('title')}
+          error={errors.title?.message}
         />
 
         {/* 상황 */}
         <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between">
             <label className="typo-label text-gray-700">상황</label>
-            <span className="typo-body-8 text-gray-400">{description.length}/1,000</span>
+            <span className="typo-body-8 text-gray-400">
+              {(descriptionValue ?? '').length}/1,000
+            </span>
           </div>
           <textarea
             maxLength={1000}
             placeholder="어떤 일이 있었는지 기록해주세요"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
+            {...register('description')}
             className="typo-body-7 h-30 w-full resize-none rounded-md border border-gray-200 bg-white px-3 py-3 text-gray-900 placeholder:text-gray-400 focus:border-gray-400 focus:outline-none"
           />
         </div>
@@ -128,13 +140,13 @@ export function TimelineFormModal({
           <p className="typo-label text-gray-700">태그</p>
           <div className="flex flex-wrap gap-2">
             {ALL_TAGS.map((tag) => {
-              const selected = selectedTags.includes(tag);
+              const selected = formHook.selectedTags.includes(tag);
               const { bg, text } = TAG_COLOR_MAP[tag];
               return (
                 <button
                   key={tag}
                   type="button"
-                  onClick={() => toggleTag(tag)}
+                  onClick={() => formHook.toggleTag(tag)}
                   className={`typo-heading-6 inline-flex items-center gap-1 rounded-full px-3 py-1.5 transition-colors ${
                     selected ? `${bg} ${text}` : 'bg-gray-100 text-gray-400'
                   }`}
@@ -147,45 +159,58 @@ export function TimelineFormModal({
           </div>
         </div>
 
-        {/* 증거자료 */}
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center justify-between">
-            <p className="typo-label text-gray-700">증거자료</p>
-            <button
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              className="typo-heading-6 hover:text-primary text-gray-400 transition-colors"
-            >
-              + 추가하기
-            </button>
-          </div>
+        {/* 증거자료 — AI 원본 증거는 편집 불가 */}
+        {canEditFiles && (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between">
+              <p className="typo-label text-gray-700">증거자료</p>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="typo-heading-6 hover:text-primary text-gray-400 transition-colors"
+              >
+                + 추가하기
+              </button>
+            </div>
 
-          <div className={files.length > 0 ? 'no-scrollbar max-h-28 overflow-y-auto' : ''}>
-            <EvidenceContent
-              previewType="file"
-              items={files}
-              onFilesAdd={handleFilesAdd}
-              onRemove={handleFileRemove}
-              onClickUpload={() => fileInputRef.current?.click()}
+            {files.isLoadingDetail ? (
+              <div className="flex items-center justify-center py-4">
+                <Spinner size="md" label="파일 목록 불러오는 중" />
+              </div>
+            ) : (
+              <div
+                className={
+                  files.attachmentItems.length > 0 ? 'no-scrollbar max-h-28 overflow-y-auto' : ''
+                }
+              >
+                <EvidenceContent
+                  previewType="file"
+                  items={files.attachmentItems}
+                  onFilesAdd={files.addFiles}
+                  onRemove={files.removeFile}
+                  onClickUpload={() => fileInputRef.current?.click()}
+                />
+              </div>
+            )}
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              onChange={(e) => {
+                if (e.target.files) files.addFiles(Array.from(e.target.files));
+                e.target.value = '';
+              }}
+              className="hidden"
             />
           </div>
-
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            onChange={(e) => {
-              if (e.target.files) handleFilesAdd(Array.from(e.target.files));
-              e.target.value = '';
-            }}
-            className="hidden"
-          />
-        </div>
+        )}
       </Modal.Body>
 
       <Modal.Footer direction="col" full>
-        <Button color="contrast" size="xl" onClick={handleSubmit}>
-          {mode === 'edit' ? '수정하기' : '추가하기'}
+        <Button color="contrast" size="xl" onClick={handleFormSubmit} disabled={isSubmitting}>
+          {isSubmitting && <Spinner size="sm" className="text-white" />}
+          {isSubmitting ? '저장 중...' : mode === 'edit' ? '수정하기' : '추가하기'}
         </Button>
       </Modal.Footer>
     </Modal.Root>

--- a/src/app/my-space/case/components/timeline/TimelineItemCard.tsx
+++ b/src/app/my-space/case/components/timeline/TimelineItemCard.tsx
@@ -18,6 +18,7 @@ import { TimelineDeleteDialog } from './TimelineDeleteDialog';
 import { TimelineFormModal } from './TimelineFormModal';
 import { EvidenceDownloadModal } from './EvidenceDownloadModal';
 import type { TimelineEvidence } from '@/types/timeline';
+import { useDeleteTimelineEvidences } from '../../hooks/useTimeline';
 
 type ModalType = 'edit' | 'delete' | 'download' | null;
 
@@ -33,6 +34,7 @@ interface TimelineItemCardProps {
  */
 export function TimelineItemCard({ date, time, evidence }: TimelineItemCardProps) {
   const [modal, setModal] = useState<ModalType>(null);
+  const deleteEvidences = useDeleteTimelineEvidences();
 
   const {
     timeline_evidence_id,
@@ -45,9 +47,8 @@ export function TimelineItemCard({ date, time, evidence }: TimelineItemCardProps
     referenced_evidence_count,
   } = evidence;
 
-  const handleDelete = () => {
-    // TODO: API 연결
-    console.log('delete', timeline_evidence_id);
+  const handleDelete = async () => {
+    await deleteEvidences.mutateAsync({ timelineEvidenceIds: [timeline_evidence_id] });
     setModal(null);
   };
 

--- a/src/app/my-space/case/components/timeline/TimelineTagBadge.tsx
+++ b/src/app/my-space/case/components/timeline/TimelineTagBadge.tsx
@@ -8,7 +8,7 @@ interface TimelineTagBadgeProps {
 
 export const TAG_ICON: Partial<Record<TimelineTag, ReactNode>> = {
   PHYSICAL_HARM: <WarningOutlineIcon width={16} height={16} />,
-  THREAT: <WarningOutlineIcon width={16} height={16} />,
+  THREAT_COERCION: <WarningOutlineIcon width={16} height={16} />,
 };
 
 export function TimelineTagBadge({ tag }: TimelineTagBadgeProps) {

--- a/src/app/my-space/case/hooks/useComplaintId.ts
+++ b/src/app/my-space/case/hooks/useComplaintId.ts
@@ -1,0 +1,6 @@
+import { useAuthStore } from '@/stores/authStore';
+
+/** 현재 로그인 유저의 complaint_id를 반환 */
+export function useComplaintId() {
+  return useAuthStore((s) => s.user!.complaint_id);
+}

--- a/src/app/my-space/case/hooks/useTimeline.ts
+++ b/src/app/my-space/case/hooks/useTimeline.ts
@@ -1,174 +1,31 @@
-import type { TimelineResponse } from '@/types/timeline';
+import { useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getTimeline,
+  updateTimelineEvidenceFormData,
+  deleteTimelineEvidences,
+  createManualTimelineEvidence,
+  downloadTimelineZip,
+} from '@/api/timeline';
+import type { TimelineFormDataRequest, DeleteTimelineEvidencesRequest } from '@/types/timeline';
+import { useComplaintId } from './useComplaintId';
 
-const MOCK_DATA: TimelineResponse = {
-  items: [
-    {
-      date: '2026-02-12',
-      events: [
-        {
-          time: 'AM 11:30',
-          evidences: [
-            {
-              timeline_evidence_id: 'e1',
-              index: 0,
-              title: '카톡 및 메세지 수신',
-              description:
-                '심야 시간에 총 15건의 카톡과 8건의 메세지로 지속적 연락, "자고있어?" "왜안자?" 등 일상 감시 암시',
-              tags: ['REPEAT'],
-              referenced_evidence_count: 1,
-              has_thumbnail: true,
-              thumbnail_url: '',
-              duration_seconds: 0,
-              is_ai_original: true,
-            },
-          ],
-        },
-        {
-          time: 'AM 11:45',
-          evidences: [
-            {
-              timeline_evidence_id: 'e2',
-              index: 1,
-              title: '주거 인근 협박 경고장',
-              description: '현관 출입문에 자필로 쓴 협박 메모지 발견',
-              tags: ['THREAT'],
-              referenced_evidence_count: 1,
-              has_thumbnail: false,
-              thumbnail_url: '',
-              duration_seconds: 0,
-              is_ai_original: true,
-            },
-          ],
-        },
-        {
-          time: 'PM 13:30',
-          evidences: [
-            {
-              timeline_evidence_id: 'e3',
-              index: 2,
-              title: '해바라기센터 상담 기록',
-              description:
-                '해바라기센터 2차례 방문 상담 기록, 스토킹 피해 상담 및 법적 대응 방안 안내받음',
-              tags: ['REFUSAL'],
-              referenced_evidence_count: 1,
-              has_thumbnail: false,
-              thumbnail_url: '',
-              duration_seconds: 0,
-              is_ai_original: false,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      date: '2026-02-16',
-      events: [
-        {
-          time: 'AM 05:30',
-          evidences: [
-            {
-              timeline_evidence_id: 'e4',
-              index: 3,
-              title: '통화 25통 수신',
-              description:
-                '부재중 전화 20통, 원치않는 통화 시도 거부 후 욕설과 협박. "만나주지않으면 가만 안 둬" 등 명백한 위협',
-              tags: ['REPEAT', 'THREAT'],
-              referenced_evidence_count: 2,
-              has_thumbnail: false,
-              thumbnail_url: '',
-              duration_seconds: 0,
-              is_ai_original: true,
-            },
-          ],
-        },
-        {
-          time: 'AM 08:30',
-          evidences: [
-            {
-              timeline_evidence_id: 'e5',
-              index: 4,
-              title: '블랙박스 영상',
-              description:
-                '차량 블랙박스 영상. 출근 중 특정 차량이 지속적으로 뒤따라오는 후방 영상 확인',
-              tags: ['THREAT'],
-              referenced_evidence_count: 1,
-              has_thumbnail: false,
-              thumbnail_url: '',
-              duration_seconds: 952,
-              is_ai_original: false,
-            },
-          ],
-        },
-        {
-          time: 'AM 08:44',
-          evidences: [
-            {
-              timeline_evidence_id: 'e6',
-              index: 5,
-              title: '2026-02-16 미행 목격',
-              description:
-                '직장 동료의 미행 발견 목격담. 지난번 여러차례바왔던 차량이어서 의심을 샀으며 직장 입장까지 지켜보다가 따남을 진술함',
-              tags: ['REPEAT'],
-              referenced_evidence_count: 1,
-              has_thumbnail: false,
-              thumbnail_url: '',
-              duration_seconds: 0,
-              is_ai_original: false,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      date: '2026-02-20',
-      events: [
-        {
-          time: 'PM 20:23',
-          evidences: [
-            {
-              timeline_evidence_id: 'e7',
-              index: 6,
-              title: '거주지 방문 후 대면 협박',
-              description:
-                '방문 시 촬영한 영상. 10분간 문을 두드렸으며, 주변 민원으로 인해 분리조치됨',
-              tags: ['THREAT'],
-              referenced_evidence_count: 1,
-              has_thumbnail: false,
-              thumbnail_url: '',
-              duration_seconds: 952,
-              is_ai_original: false,
-            },
-          ],
-        },
-        {
-          time: 'PM 20:48',
-          evidences: [
-            {
-              timeline_evidence_id: 'e8',
-              index: 7,
-              title: '경찰서 방문 후 진정서 작성',
-              description: '진정서 작성 후 피해자 보호 프로그램을 신청함',
-              tags: ['REFUSAL'],
-              referenced_evidence_count: 1,
-              has_thumbnail: false,
-              thumbnail_url: '',
-              duration_seconds: 0,
-              is_ai_original: false,
-            },
-          ],
-        },
-      ],
-    },
-  ],
+// ─── query key ──────────────────────────────────────────
+
+const timelineKeys = {
+  detail: (complaintId: string) => ['timeline', complaintId] as const,
 };
 
-/**
- * 타임라인 목업 데이터 훅
- * - API 연결 전 UI 개발용
- * - 추후 useSuspenseQuery로 교체 예정: GET /api/v1/{complaint_id}/timeline
- */
-export function useTimeline(_complaintId: string) {
-  const groups = MOCK_DATA.items;
+// ─── 조회 ────────────────────────────────────────────────
+
+export function useTimeline() {
+  const complaintId = useComplaintId();
+
+  const { data } = useSuspenseQuery({
+    queryKey: timelineKeys.detail(complaintId),
+    queryFn: () => getTimeline(complaintId),
+  });
+
+  const groups = data.items;
   const allDates = groups.map((g) => g.date);
   const allTags = [
     ...new Set(
@@ -177,4 +34,62 @@ export function useTimeline(_complaintId: string) {
   ];
 
   return { groups, allDates, allTags };
+}
+
+// ─── mutations ───────────────────────────────────────────
+
+/** 직접 추가 증거 생성 (폼 데이터만) */
+export function useCreateTimelineEvidence() {
+  const complaintId = useComplaintId();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: TimelineFormDataRequest) =>
+      createManualTimelineEvidence(complaintId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: timelineKeys.detail(complaintId) });
+    },
+  });
+}
+
+/** AI 원본 또는 직접 추가 증거의 폼 데이터 수정 */
+export function useUpdateTimelineEvidence() {
+  const complaintId = useComplaintId();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      timelineEvidenceId,
+      payload,
+    }: {
+      timelineEvidenceId: string;
+      payload: TimelineFormDataRequest;
+    }) => updateTimelineEvidenceFormData(complaintId, timelineEvidenceId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: timelineKeys.detail(complaintId) });
+    },
+  });
+}
+
+/** 타임라인 증거 복수 삭제 */
+export function useDeleteTimelineEvidences() {
+  const complaintId = useComplaintId();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: DeleteTimelineEvidencesRequest) =>
+      deleteTimelineEvidences(complaintId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: timelineKeys.detail(complaintId) });
+    },
+  });
+}
+
+/** ZIP 다운로드 presigned URL 발급 */
+export function useDownloadTimeline() {
+  const complaintId = useComplaintId();
+
+  return useMutation({
+    mutationFn: () => downloadTimelineZip(complaintId),
+  });
 }

--- a/src/app/my-space/case/hooks/useTimelineFiles.ts
+++ b/src/app/my-space/case/hooks/useTimelineFiles.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 import { getTimelineEvidenceDetail } from '@/api/timeline';
@@ -43,7 +43,6 @@ export function useTimelineFiles({
   evidence,
 }: UseTimelineFilesParams) {
   const complaintId = useComplaintId();
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [localFiles, setLocalFiles] = useState<LocalFile[]>([]);
   const [serverFiles, setServerFiles] = useState<TimelineReferencedEvidence[]>([]);
@@ -103,7 +102,6 @@ export function useTimelineFiles({
   ];
 
   return {
-    fileInputRef,
     attachmentItems,
     isLoadingDetail,
     addFiles,

--- a/src/app/my-space/case/hooks/useTimelineFiles.ts
+++ b/src/app/my-space/case/hooks/useTimelineFiles.ts
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import { getTimelineEvidenceDetail } from '@/api/timeline';
+import type { TimelineEvidence, TimelineReferencedEvidence } from '@/types/timeline';
+import type { EvidencePreviewItem } from '@/types/evidence';
+import { filterValidFiles } from '../components/evidence/validate';
+import type { FileCategoryKey } from '../components/evidence/constants';
+import { useComplaintId } from './useComplaintId';
+
+// ─── 공유 타입 / 상수 ─────────────────────────────────────
+
+/** useTimelineSubmit에서도 import해서 씀 */
+export type LocalFile = { id: string; file: File };
+
+/** 타입 제한 없음 (API 스펙 참고) */
+export const TIMELINE_ATTACHMENT_CONFIG = {
+  maxFiles: 10,
+  categories: ['IMAGE', 'VIDEO', 'AUDIO', 'DOCUMENT'] as FileCategoryKey[],
+};
+
+// ─── 기능 ────────────────────────────────────────────────
+
+interface UseTimelineFilesParams {
+  open: boolean;
+  isEditMode: boolean;
+  /** is_ai_original=true면 false — 파일 편집 불가 */
+  canEditFiles: boolean;
+  evidence?: TimelineEvidence;
+}
+
+/**
+ * 타임라인 파일 상태 관리 훅
+ *
+ * - 수정 모드에서 서버 파일 목록 조회 (useQuery)
+ * - 파일 추가 / 제거 (로컬 / 서버 분기)
+ * - 제출 시 필요한 uploadFiles / deleteIds 제공
+ */
+export function useTimelineFiles({
+  open,
+  isEditMode,
+  canEditFiles,
+  evidence,
+}: UseTimelineFilesParams) {
+  const complaintId = useComplaintId();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [localFiles, setLocalFiles] = useState<LocalFile[]>([]);
+  const [serverFiles, setServerFiles] = useState<TimelineReferencedEvidence[]>([]);
+  const [pendingDeleteIds, setPendingDeleteIds] = useState<string[]>([]);
+
+  // 수정 모드 + 직접 추가 증거일 때만 기존 참조 증거 조회
+  const { data: detailData, isLoading: isLoadingDetail } = useQuery({
+    queryKey: ['timeline-evidence-detail', complaintId, evidence?.timeline_evidence_id],
+    queryFn: () => getTimelineEvidenceDetail(complaintId, evidence!.timeline_evidence_id),
+    enabled: open && isEditMode && canEditFiles && !!evidence,
+  });
+
+  /** 모달 열릴 때마다 로컬 파일 / 삭제 예정 목록 초기화 */
+  useEffect(() => {
+    if (!open) return;
+    setLocalFiles([]);
+    setPendingDeleteIds([]);
+  }, [open]);
+
+  /** 서버 파일 목록 — detailData 로드 완료 시 세팅 */
+  useEffect(() => {
+    if (!open || !detailData) return;
+    setServerFiles(detailData.evidences);
+  }, [open, detailData]);
+
+  /** 파일 추가 — 타입·크기·길이·개수 검증 후 임시 ID 부여 */
+  const addFiles = async (files: File[]) => {
+    const { valid, rejected } = await filterValidFiles(
+      files,
+      TIMELINE_ATTACHMENT_CONFIG,
+      localFiles.length + serverFiles.length,
+    );
+    if (rejected.length > 0) {
+      toast.error(`${rejected.length}개 파일은 업로드할 수 없습니다.`);
+    }
+    setLocalFiles((prev) => [...prev, ...valid.map((file) => ({ id: crypto.randomUUID(), file }))]);
+  };
+
+  /** 파일 제거 — 로컬이면 즉시 삭제, 서버면 삭제 예약 + 낙관적 UI 제거 */
+  const removeFile = (id: string) => {
+    if (localFiles.some((f) => f.id === id)) {
+      setLocalFiles((prev) => prev.filter((f) => f.id !== id));
+    } else {
+      setPendingDeleteIds((prev) => [...prev, id]);
+      setServerFiles((prev) => prev.filter((f) => f.referenced_id !== id));
+    }
+  };
+
+  /** EvidenceContent용 통일 형식 — 서버 파일 + 로컬 파일 합산 */
+  const attachmentItems: EvidencePreviewItem[] = [
+    ...serverFiles.map((f) => ({
+      id: f.referenced_id,
+      filename: f.filename,
+      sizeBytes: f.size_bytes,
+    })),
+    ...localFiles.map(({ id, file }) => ({ id, filename: file.name, sizeBytes: file.size })),
+  ];
+
+  return {
+    fileInputRef,
+    attachmentItems,
+    isLoadingDetail,
+    addFiles,
+    removeFile,
+    /** 제출 시 업로드할 신규 파일 */
+    getUploadFiles: () => localFiles,
+    /** 제출 시 삭제할 서버 파일 ID 목록 */
+    getDeleteIds: () => pendingDeleteIds,
+  };
+}

--- a/src/app/my-space/case/hooks/useTimelineForm.ts
+++ b/src/app/my-space/case/hooks/useTimelineForm.ts
@@ -1,63 +1,90 @@
-import { useState } from 'react';
-import type { TimelineTag, TimelineEvidence } from '@/types/timeline';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import type { TimelineEvidence, TimelineTag } from '@/types/timeline';
 
-interface UseTimelineFormOptions {
+// ─── 검증 ────────────────────────────────────────────────
+
+export const timelineFormSchema = z.object({
+  date: z.string().min(1, '날짜를 선택해주세요'),
+  time: z.string().min(1, '시간을 입력해주세요'),
+  title: z.string().min(1, '제목을 입력해주세요'),
+  description: z.string(),
+});
+
+export type TimelineFormValues = z.infer<typeof timelineFormSchema>;
+
+// ─── 기능 ────────────────────────────────────────────────
+
+interface UseTimelineFormParams {
+  open: boolean;
   initialDate?: string;
   initialTime?: string;
   evidence?: TimelineEvidence;
 }
 
 /**
- * 타임라인 추가/수정 폼 상태 및 핸들러
- * TODO: API 연결 시 RHF + zod로 교체
+ * 타임라인 폼 상태 훅
+ *
+ * - RHF 폼 (date, time, title, description)
+ * - 태그 멀티 선택
+ * - 시간 입력 마스킹 / 범위 정규화
+ * - 모달 열릴 때 초기값으로 reset
  */
 export function useTimelineForm({
+  open,
   initialDate = '',
   initialTime = '',
   evidence,
-}: UseTimelineFormOptions) {
-  const [date, setDate] = useState(initialDate);
-  const [time, setTime] = useState(initialTime.replace(/^(AM|PM)\s*/i, '').trim() || '00:00');
-  const [title, setTitle] = useState(evidence?.title ?? '');
-  const [description, setDescription] = useState(evidence?.description ?? '');
-  const [selectedTags, setSelectedTags] = useState<TimelineTag[]>(evidence?.tags ?? []);
+}: UseTimelineFormParams) {
+  const [selectedTags, setSelectedTags] = useState<TimelineTag[]>([]);
 
+  const form = useForm<TimelineFormValues>({
+    resolver: zodResolver(timelineFormSchema),
+    mode: 'onChange',
+    defaultValues: { date: '', time: '00:00', title: '', description: '' },
+  });
+
+  /** 모달 열릴 때마다 폼 / 태그 초기화 */
+  useEffect(() => {
+    if (!open) return;
+    const rawTime = initialTime.replace(/^(AM|PM)\s*/i, '').trim() || '00:00';
+    form.reset({
+      date: initialDate,
+      time: rawTime,
+      title: evidence?.title ?? '',
+      description: evidence?.description ?? '',
+    });
+    setSelectedTags(evidence?.tags ?? []);
+    // open이 true로 바뀔 때만 초기화하면 되므로 의도적으로 의존성 생략
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  /** 시간 입력 마스킹 (HH:MM) */
   const handleTimeChange = (value: string) => {
     const digits = value.replace(/\D/g, '').slice(0, 4);
-    if (digits.length <= 2) {
-      setTime(digits);
-    } else {
-      setTime(`${digits.slice(0, 2)}:${digits.slice(2)}`);
-    }
+    const formatted = digits.length <= 2 ? digits : `${digits.slice(0, 2)}:${digits.slice(2)}`;
+    form.setValue('time', formatted, { shouldValidate: true });
   };
 
+  /** 시간 blur — 범위 정규화 (0~23시, 0~59분) */
   const handleTimeBlur = () => {
-    const digits = time.replace(/\D/g, '').padEnd(4, '0');
+    const digits = form.getValues('time').replace(/\D/g, '').padEnd(4, '0');
     const h = Math.min(parseInt(digits.slice(0, 2), 10), 23)
       .toString()
       .padStart(2, '0');
     const m = Math.min(parseInt(digits.slice(2, 4), 10), 59)
       .toString()
       .padStart(2, '0');
-    setTime(`${h}:${m}`);
+    form.setValue('time', `${h}:${m}`, { shouldValidate: true });
   };
 
+  /** 태그 토글 */
   const toggleTag = (tag: TimelineTag) =>
     setSelectedTags((prev) =>
       prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
     );
 
-  return {
-    date,
-    setDate,
-    time,
-    handleTimeChange,
-    handleTimeBlur,
-    title,
-    setTitle,
-    description,
-    setDescription,
-    selectedTags,
-    toggleTag,
-  };
+  return { form, selectedTags, toggleTag, handleTimeChange, handleTimeBlur };
 }

--- a/src/app/my-space/case/hooks/useTimelineSubmit.ts
+++ b/src/app/my-space/case/hooks/useTimelineSubmit.ts
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { uploadToS3 } from '@/api/evidence';
+import {
+  getManualReferencedEvidencePresignedUrls,
+  registerManualReferencedEvidences,
+  deleteManualReferencedEvidences,
+} from '@/api/timeline';
+import { buildPresignedUrlItems } from '../components/evidence/validate';
+import type { TimelineEvidence, TimelineTag } from '@/types/timeline';
+import type { TimelineFormValues } from './useTimelineForm';
+import { type LocalFile, TIMELINE_ATTACHMENT_CONFIG } from './useTimelineFiles';
+import { useCreateTimelineEvidence, useUpdateTimelineEvidence } from './useTimeline';
+import { useComplaintId } from './useComplaintId';
+
+// ─── 타입 ────────────────────────────────────────────────
+
+export interface SubmitParams {
+  formValues: TimelineFormValues;
+  tags: TimelineTag[];
+  uploadFiles: LocalFile[];
+  deleteIds: string[];
+}
+
+interface UseTimelineSubmitParams {
+  mode: 'add' | 'edit';
+  canEditFiles: boolean;
+  evidence?: TimelineEvidence;
+  onClose: () => void;
+}
+
+// ─── 기능 ────────────────────────────────────────────────
+
+/**
+ * 타임라인 제출 흐름 훅
+ *
+ * 추가: create → 파일 업로드
+ * 수정: update → 파일 삭제 → 파일 업로드
+ *
+ * - 파일 업로드는 presigned URL → S3 PUT → register 3단계
+ * - canEditFiles=false(AI 원본)면 파일 관련 API 전부 건너뜀
+ */
+export function useTimelineSubmit({
+  mode,
+  canEditFiles,
+  evidence,
+  onClose,
+}: UseTimelineSubmitParams) {
+  const complaintId = useComplaintId();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const createEvidence = useCreateTimelineEvidence();
+  const updateEvidence = useUpdateTimelineEvidence();
+
+  const submit = async ({ formValues, tags, uploadFiles, deleteIds }: SubmitParams) => {
+    setIsSubmitting(true);
+    try {
+      const payload = { ...formValues, tags };
+
+      // 1단계: 폼 데이터 저장 → timeline_evidence_id 획득
+      const { timeline_evidence_id } =
+        mode === 'edit'
+          ? await updateEvidence.mutateAsync({
+              timelineEvidenceId: evidence!.timeline_evidence_id,
+              payload,
+            })
+          : await createEvidence.mutateAsync(payload);
+
+      if (canEditFiles) {
+        // 2단계: 삭제 예정 참조 증거 일괄 삭제
+        if (deleteIds.length > 0) {
+          await deleteManualReferencedEvidences(complaintId, timeline_evidence_id, {
+            referencedManualEvidenceIds: deleteIds,
+          });
+        }
+
+        // 3단계: 신규 파일 업로드 (presigned URL → S3 → register)
+        if (uploadFiles.length > 0) {
+          const files = uploadFiles.map((f) => f.file);
+          const presignedUrlItems = await buildPresignedUrlItems(
+            files,
+            TIMELINE_ATTACHMENT_CONFIG.categories,
+          );
+
+          const { items: presignedItems } = await getManualReferencedEvidencePresignedUrls(
+            complaintId,
+            timeline_evidence_id,
+            { items: presignedUrlItems },
+          );
+
+          await Promise.all(presignedItems.map((p, i) => uploadToS3(p.url, files[i])));
+
+          await registerManualReferencedEvidences(complaintId, timeline_evidence_id, {
+            items: presignedItems.map((p) => ({
+              referencedManualEvidenceId: p.referenced_manual_evidence_id,
+              filename: p.filename,
+            })),
+          });
+        }
+      }
+
+      onClose();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return { submit, isSubmitting };
+}

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -108,7 +108,7 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
         <CaseProgress currentStep={step} />
         {/* 스텝별 컨텐츠 조건부 렌더링 */}
         {step === 1 && <StepCollect complaintId={complaintId} />}
-        {step === 2 && <StepTimeline complaintId={complaintId} />}
+        {step === 2 && <StepTimeline />}
         {step === 3 && <StepDocument />}
         {step === 4 && <StepComplete />}
       </div>

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -107,10 +107,16 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
         {/* 4단계 프로그레스 바 */}
         <CaseProgress currentStep={step} />
         {/* 스텝별 컨텐츠 조건부 렌더링 */}
-        {step === 1 && <StepCollect complaintId={complaintId} />}
-        {step === 2 && <StepTimeline />}
-        {step === 3 && <StepDocument />}
-        {step === 4 && <StepComplete />}
+        <QueryErrorResetBoundary>
+          {({ reset }) => (
+            <ErrorBoundary FallbackComponent={CaseErrorFallback} onReset={reset}>
+              {step === 1 && <StepCollect complaintId={complaintId} />}
+              {step === 2 && <StepTimeline />}
+              {step === 3 && <StepDocument />}
+              {step === 4 && <StepComplete />}
+            </ErrorBoundary>
+          )}
+        </QueryErrorResetBoundary>
       </div>
     </div>
   );

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -1,21 +1,26 @@
 // ─── 태그 ────────────────────────────────────────────────
 
-export type TimelineTag = 'REPEAT' | 'PHYSICAL_HARM' | 'THREAT' | 'SEXUAL_INSULT' | 'REFUSAL';
+export type TimelineTag =
+  | 'REPEAT'
+  | 'PHYSICAL_HARM'
+  | 'THREAT_COERCION'
+  | 'SEXUAL_INSULT'
+  | 'REFUSAL_INTENT';
 
 export const TAG_LABEL_MAP: Record<TimelineTag, string> = {
   REPEAT: '반복',
   PHYSICAL_HARM: '신체피해',
-  THREAT: '위협·강압',
+  THREAT_COERCION: '위협·강압',
   SEXUAL_INSULT: '성적·모욕',
-  REFUSAL: '거절 의사',
+  REFUSAL_INTENT: '거절 의사',
 };
 
 export const TAG_COLOR_MAP: Record<TimelineTag, { bg: string; text: string }> = {
   REPEAT: { bg: 'bg-warning/10', text: 'text-warning' },
   PHYSICAL_HARM: { bg: 'bg-error/10', text: 'text-error' },
-  THREAT: { bg: 'bg-error/10', text: 'text-error' },
+  THREAT_COERCION: { bg: 'bg-error/10', text: 'text-error' },
   SEXUAL_INSULT: { bg: 'bg-warning/10', text: 'text-warning' },
-  REFUSAL: { bg: 'bg-info/10', text: 'text-info' },
+  REFUSAL_INTENT: { bg: 'bg-info/10', text: 'text-info' },
 };
 
 // ─── API 응답 타입 ────────────────────────────────────────
@@ -45,4 +50,114 @@ export type TimelineDateGroup = {
 
 export type TimelineResponse = {
   items: TimelineDateGroup[];
+};
+
+// ─── 타임라인 증거 상세 조회 ──────────────────────────────
+
+export type TimelineReferencedEvidence = {
+  referenced_id: string;
+  filename: string;
+  size_bytes: number;
+  thumbnail_url: string;
+  duration_seconds: number;
+  evidence_type: string;
+  file_type: string;
+};
+
+export type TimelineEvidenceDetail = {
+  timeline_evidence_id: string;
+  index: number;
+  date: string;
+  time: string;
+  title: string;
+  description: string;
+  tags: TimelineTag[];
+  referenced_evidence_count: number;
+  is_ai_original: boolean;
+  evidences: TimelineReferencedEvidence[];
+};
+
+// ─── 폼 데이터 요청/응답 ──────────────────────────────────
+
+export type TimelineFormDataRequest = {
+  date: string; // e.g. "2026-02-12"
+  time: string; // e.g. "11:30"
+  title: string;
+  description: string;
+  tags: TimelineTag[];
+};
+
+export type TimelineFormDataResponse = {
+  timeline_evidence_id: string;
+  index: number;
+  date: string;
+  time: string;
+  title: string;
+  description: string;
+  tags: TimelineTag[];
+};
+
+// ─── 직접 추가 증거 — 참조 증거 presigned URL ────────────
+
+export type ManualReferencedEvidencePresignedUrlItem = {
+  index: number;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  durationSeconds?: number; // 영상/음성만 사용
+};
+
+export type ManualReferencedEvidencePresignedUrlRequest = {
+  items: ManualReferencedEvidencePresignedUrlItem[];
+};
+
+export type ManualReferencedEvidencePresignedUrlResponseItem = {
+  index: number;
+  filename: string;
+  url: string;
+  referenced_manual_evidence_id: string;
+};
+
+export type ManualReferencedEvidencePresignedUrlResponse = {
+  items: ManualReferencedEvidencePresignedUrlResponseItem[];
+};
+
+// ─── 직접 추가 증거 — 참조 증거 등록 ────────────────────
+
+export type ManualReferencedEvidenceRegisterItem = {
+  referencedManualEvidenceId: string;
+  filename: string;
+};
+
+export type ManualReferencedEvidenceRegisterRequest = {
+  items: ManualReferencedEvidenceRegisterItem[];
+};
+
+export type ManualReferencedEvidenceRegisterResponseItem = {
+  referenced_manual_evidence_id: string;
+  file_type: string;
+  filename: string;
+  content_type: string;
+  size_bytes: number;
+  duration_seconds: number;
+};
+
+export type ManualReferencedEvidenceRegisterResponse = {
+  items: ManualReferencedEvidenceRegisterResponseItem[];
+};
+
+// ─── 삭제 요청 ───────────────────────────────────────────
+
+export type DeleteTimelineEvidencesRequest = {
+  timelineEvidenceIds: string[];
+};
+
+export type DeleteManualReferencedEvidencesRequest = {
+  referencedManualEvidenceIds: string[];
+};
+
+// ─── 다운로드 ────────────────────────────────────────────
+
+export type TimelineDownloadResponse = {
+  download_url: string;
 };


### PR DESCRIPTION
## 작업 내용

Step 2(타임라인 정리) UI를 실제 백엔드 API와 연결했습니다.

### API 연결

**타임라인 조회**
- `GET /{complaint_id}/timeline` — `useSuspenseQuery`로 전환, mock 데이터 제거
- Suspense + ErrorBoundary 경계 추가로 로딩/에러 처리 위임

**타임라인 수정**
- `PATCH /{complaint_id}/timeline/evidences/{id}/form-data`
- `useUpdateTimelineEvidence` — 성공 시 타임라인 캐시 무효화

**타임라인 삭제**
- `DELETE /{complaint_id}/timeline/evidences` (복수 삭제)
- `useDeleteTimelineEvidences` — 성공 시 타임라인 캐시 무효화

**직접 추가**
- `POST /{complaint_id}/timeline/evidences/manual/form-data`
- `useCreateTimelineEvidence`

**증거 상세 조회**
- `GET /{complaint_id}/timeline/evidences/{id}` — 수정 모달 진입 시 로드

**참조 증거 파일 업로드**
- `POST presigned-url` → S3 PUT → `POST register` 3단계 업로드
- `DELETE /manual/referenced-evidences` — 파일 삭제 연결

**ZIP 다운로드**
- `POST /{complaint_id}/timeline/download/zip` — presigned URL 발급 후 브라우저 다운로드

---

### 훅 분리

| 훅 | 역할 |
|----|------|
| `useTimeline` | 타임라인 조회 + mutations |
| `useTimelineForm` | RHF + zod 폼 상태 관리 |
| `useTimelineFiles` | 파일 추가/삭제 상태, 서버 파일 조회 |
| `useTimelineSubmit` | 제출 흐름 (create/update → 파일 삭제 → 파일 업로드) |

---

### 파일 검증

- `filterValidFiles`로 타입·크기·길이·개수 검증
- rejected 파일 `toast.error()` 표시

---

### ErrorBoundary 개선

스텝 컨텐츠 영역에 별도 ErrorBoundary를 추가했습니다.

기존에는 `StepTimeline` 에러가 페이지 전체를 감싸는 ErrorBoundary까지 전파되어
`CaseHeader`(이전/다음 버튼 포함)까지 사라지는 문제가 있었습니다.

기존
ErrorBoundary
└── CasePageContent         ← 에러 시 전체 교체
├── CaseHeader           ← 같이 사라짐
└── StepTimeline         ← 에러 발생

변경 후
ErrorBoundary               ← complaint 에러만 잡음
└── CasePageContent
├── CaseHeader           ← 항상 유지
└── ErrorBoundary        ← 스텝 에러 격리
└── StepTimeline     ← 에러 발생해도 헤더 유지



---

### 참고사항

- `is_ai_original: true`인 증거는 참조 증거 파일 편집 불가 (`canEditFiles = !is_ai_original`)
- 타임라인이 없는 경우 (`TIMELINE_NOT_FOUND`) — AI 생성 플로우는 별도 이슈로 분리

## 이슈 번호
close #51 

## 스크린샷 (선택)

<img width="640" height="4506" alt="image" src="https://github.com/user-attachments/assets/a2ea8e2d-b8c6-4b7c-bd6e-cfd1309ff853" />
