### PR TITLE
[FEAT][#53]: Step 1 → Step 2 AI 타임라인 자동 생성 플로우 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "prepare": "husky",
     "db:start": "node --env-file=.env.local scripts/db.mjs start",
     "db:status": "node --env-file=.env.local scripts/db.mjs status",
-    "db:stop": "node --env-file=.env.local scripts/db.mjs stop"
+    "db:stop": "node --env-file=.env.local scripts/db.mjs stop",
+    "sse:start": "node --env-file=.env.local scripts/sse.mjs start",
+    "sse:status": "node --env-file=.env.local scripts/sse.mjs status",
+    "sse:stop": "node --env-file=.env.local scripts/sse.mjs stop"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/scripts/sse.mjs
+++ b/scripts/sse.mjs
@@ -1,0 +1,55 @@
+const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080';
+
+const command = process.argv[2];
+
+async function startSse() {
+  console.log('🚀 SSE 서버 시작 요청 중...');
+  const res = await fetch(`${BASE_URL}/api/v1/server_cost/sse/start`, { method: 'POST' });
+  if (res.ok) {
+    console.log('✅ SSE 서버 시작 요청 완료! 약 1분 후 사용 가능');
+  } else {
+    console.error('❌ SSE 서버 시작 실패:', res.status);
+  }
+}
+
+async function getStatus() {
+  console.log('🔍 SSE 서버 상태 확인 중...');
+  const res = await fetch(`${BASE_URL}/api/v1/server_cost/sse/status`);
+  const data = await res.json();
+  if (data.status === 'available') {
+    console.log('✅ SSE 서버 사용 가능!');
+  } else {
+    console.log('⏳ SSE 서버 아직 준비 중...');
+  }
+}
+
+async function stopSse() {
+  console.log('🛑 SSE 서버 중지 요청 중...');
+  const res = await fetch(`${BASE_URL}/api/v1/server_cost/sse/stop`, { method: 'POST' });
+  if (res.ok) {
+    console.log('✅ SSE 서버 중지 요청 완료! 약 10초 후 중지');
+  } else {
+    console.error('❌ SSE 서버 중지 실패:', res.status);
+  }
+}
+
+switch (command) {
+  case 'start':
+    startSse();
+    break;
+  case 'status':
+    getStatus();
+    break;
+  case 'stop':
+    stopSse();
+    break;
+  default:
+    console.log(`
+사용법:
+  pnpm sse:start   - SSE 서버 시작 (약 1분 소요)
+  pnpm sse:status  - SSE 서버 상태 확인
+  pnpm sse:stop    - SSE 서버 중지 (약 10초 소요)
+
+🚨 실시간 진행률 API 테스트할 때만 실행할 것 (비용 발생)
+    `);
+}

--- a/src/api/timeline.ts
+++ b/src/api/timeline.ts
@@ -11,6 +11,10 @@ import type {
   DeleteTimelineEvidencesRequest,
   DeleteManualReferencedEvidencesRequest,
   TimelineDownloadResponse,
+  NeedToGenerateResponse,
+  RequestGenerateResponse,
+  CurrentTaskIdResponse,
+  SseServerUrlResponse,
 } from '@/types/timeline';
 
 // ─── 타임라인 조회 ────────────────────────────────────────
@@ -120,6 +124,43 @@ export async function deleteManualReferencedEvidences(
 export async function downloadTimelineZip(complaintId: string) {
   const res = await axiosInstance.post<TimelineDownloadResponse>(
     `/api/v1/${complaintId}/timeline/download/zip`,
+  );
+  return res.data;
+}
+
+// ─── AI 생성 ─────────────────────────────────────────────
+
+/** SSE 서버 URL 조회 */
+export async function getSseServerUrl() {
+  const res = await axiosInstance.get<SseServerUrlResponse>('/api/v1/sse/server-url');
+  return res.data;
+}
+
+/** 타임라인 생성 필요 여부 확인 */
+export async function needToGenerateTimeline(complaintId: string) {
+  const res = await axiosInstance.get<NeedToGenerateResponse>(
+    `/api/v1/${complaintId}/ai/timeline/need-to-generate`,
+  );
+  return res.data;
+}
+
+/** AI 타임라인 생성 요청 */
+export async function requestGenerateTimeline(
+  complaintId: string,
+  llmType: 'mock' | 'openAI' = 'mock',
+) {
+  const res = await axiosInstance.post<RequestGenerateResponse>(
+    `/api/v1/${complaintId}/ai/timeline/request/generate`,
+    {},
+    { params: { llm_type: llmType } },
+  );
+  return res.data;
+}
+
+/** 재진입 시 현재 task_id 조회 */
+export async function getCurrentTaskId(complaintId: string) {
+  const res = await axiosInstance.get<CurrentTaskIdResponse>(
+    `/api/v1/${complaintId}/ai/timeline/current-task-id`,
   );
   return res.data;
 }

--- a/src/app/my-space/case/components/TimelineGeneratingView.tsx
+++ b/src/app/my-space/case/components/TimelineGeneratingView.tsx
@@ -1,0 +1,120 @@
+import type { TimelineProgressData } from '@/types/timeline';
+
+interface TimelineGeneratingViewProps {
+  progressData: TimelineProgressData | null;
+}
+
+/** 각 스테이지의 라벨과 바 너비 정의 */
+const STAGE_CONFIGS = [
+  { label: '준비', barWidth: 48 },
+  { label: '처리 중', barWidth: 160 },
+  { label: '마무리', barWidth: 48 },
+] as const;
+
+type Stage = 1 | 2 | 3;
+
+/** SSE status → UI 단계 변환 */
+function getStage(status: TimelineProgressData['status']): Stage {
+  if (status === 'PROCESSING') return 2;
+  if (status === 'DONE') return 3;
+  return 1;
+}
+
+/** 각 스테이지 바의 채움 비율 계산 */
+function getBarFill(
+  stageNum: Stage,
+  currentStage: Stage,
+  processed: number,
+  total: number,
+): number {
+  if (currentStage < stageNum) return 0;
+  if (currentStage > stageNum) return 100;
+  // currentStage === stageNum (현재 진행 중인 스테이지)
+  if (stageNum === 1) return 30; // 준비 중 — 고정 초기값
+  if (stageNum === 2) return total > 0 ? (processed / total) * 100 : 0;
+  return 100;
+}
+
+const STAGE_MESSAGE: Record<Stage, string> = {
+  1: '타임라인이 준비중이에요',
+  2: '',
+  3: '타임라인을 정리하고 있어요',
+};
+
+const STAGE_TIME: Record<Stage, string> = {
+  1: '20분',
+  2: '15분',
+  3: '2분',
+};
+
+/**
+ * AI 타임라인 생성 중 진행률 UI
+ *
+ * 각 스테이지는 [라벨 → 도트 → 프로그레스 바] 세로 구조로 이루어짐
+ * - 준비(PENDING) / 처리 중(PROCESSING) / 마무리(DONE) 3단계로 표시
+ * - 처리 중 단계에서 processed/total 기반으로 바 채움
+ */
+export function TimelineGeneratingView({ progressData }: TimelineGeneratingViewProps) {
+  const stage = getStage(progressData?.status ?? null);
+  const processed = progressData?.processed ?? 0;
+  const total = progressData?.total ?? 0;
+
+  const message =
+    stage === 2 ? `타임라인이 처리중이에요 (${processed}/${total})` : STAGE_MESSAGE[stage];
+
+  return (
+    <div className="flex flex-col items-center gap-12 bg-white px-7 py-6">
+      {/* 3단계 진행 표시 */}
+      <div className="items-star flex gap-1.5">
+        {STAGE_CONFIGS.map((config, i) => {
+          const stageNum = (i + 1) as Stage;
+          const isActive = stage === stageNum;
+          const isFuture = stage < stageNum;
+          const barFill = getBarFill(stageNum, stage, processed, total);
+
+          return (
+            <div
+              key={config.label}
+              className="flex flex-col items-center gap-2"
+              style={{ width: config.barWidth }}
+            >
+              {/* 라벨 */}
+              <span
+                className={`text-center text-xs transition-colors duration-300 ${
+                  isActive ? 'font-bold text-gray-800' : 'font-normal text-gray-300'
+                }`}
+              >
+                {config.label}
+              </span>
+
+              {/* 도트 */}
+              <div
+                className={`h-1.5 w-1.5 rounded-full transition-colors duration-300 ${
+                  isFuture ? 'bg-gray-200' : 'bg-primary'
+                }`}
+              />
+
+              {/* 프로그레스 바 */}
+              <div
+                className={`relative h-2 w-full overflow-hidden rounded-full transition-colors duration-300 ${
+                  isFuture ? 'bg-gray-200' : 'bg-primary-light'
+                }`}
+              >
+                <div
+                  className="bg-primary absolute inset-y-0 left-0 transition-all duration-500"
+                  style={{ width: `${barFill}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 상태 텍스트 */}
+      <div className="flex flex-col items-center gap-2">
+        <p className="typo-heading-3 text-gray-500">{message}</p>
+        <p className="typo-body-7 text-gray-500">예상 남은 시간 : {STAGE_TIME[stage]}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/my-space/case/components/TimelineGeneratingView.tsx
+++ b/src/app/my-space/case/components/TimelineGeneratingView.tsx
@@ -1,7 +1,10 @@
+import { useTimelineGenerate } from '../hooks/useTimelineGenerate';
+import { Spinner } from '@/components/Spinner';
 import type { TimelineProgressData } from '@/types/timeline';
 
 interface TimelineGeneratingViewProps {
-  progressData: TimelineProgressData | null;
+  taskId: string;
+  onDone: () => void;
 }
 
 /** 각 스테이지의 라벨과 바 너비 정의 */
@@ -47,8 +50,20 @@ const STAGE_MESSAGE: Record<Stage, string> = {
  * 각 스테이지는 [라벨 → 도트 → 프로그레스 바] 세로 구조로 이루어짐
  * - 준비(PENDING) / 처리 중(PROCESSING) / 마무리(DONE) 3단계로 표시
  * - 처리 중 단계에서 processed/total 기반으로 바 채움
+ * - SSE 에러 발생 시 throw → 외부 ErrorBoundary가 처리
  */
-export function TimelineGeneratingView({ progressData }: TimelineGeneratingViewProps) {
+export function TimelineGeneratingView({ taskId, onDone }: TimelineGeneratingViewProps) {
+  const { progressData } = useTimelineGenerate({ taskId, onDone });
+
+  // SSE 이벤트 수신 전 — 스피너 표시
+  if (!progressData) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Spinner size="lg" className="text-primary" />
+      </div>
+    );
+  }
+
   const stage = getStage(progressData?.status ?? null);
   const processed = progressData?.processed ?? 0;
   const total = progressData?.total ?? 0;

--- a/src/app/my-space/case/components/TimelineGeneratingView.tsx
+++ b/src/app/my-space/case/components/TimelineGeneratingView.tsx
@@ -41,12 +41,6 @@ const STAGE_MESSAGE: Record<Stage, string> = {
   3: '타임라인을 정리하고 있어요',
 };
 
-const STAGE_TIME: Record<Stage, string> = {
-  1: '20분',
-  2: '15분',
-  3: '2분',
-};
-
 /**
  * AI 타임라인 생성 중 진행률 UI
  *
@@ -113,7 +107,9 @@ export function TimelineGeneratingView({ progressData }: TimelineGeneratingViewP
       {/* 상태 텍스트 */}
       <div className="flex flex-col items-center gap-2">
         <p className="typo-heading-3 text-gray-500">{message}</p>
-        <p className="typo-body-7 text-gray-500">예상 남은 시간 : {STAGE_TIME[stage]}</p>
+        <p className="typo-body-7 text-gray-500">
+          * 화면을 종료해도 타임라인 처리는 계속 진행됩니다
+        </p>
       </div>
     </div>
   );

--- a/src/app/my-space/case/components/index.ts
+++ b/src/app/my-space/case/components/index.ts
@@ -4,3 +4,4 @@ export { StepCollect } from './StepCollect';
 export { StepTimeline } from './StepTimeline';
 export { StepDocument } from './StepDocument';
 export { StepComplete } from './StepComplete';
+export { TimelineGeneratingView } from './TimelineGeneratingView';

--- a/src/app/my-space/case/hooks/useEvidence.ts
+++ b/src/app/my-space/case/hooks/useEvidence.ts
@@ -31,6 +31,7 @@ import type {
 } from '@/types/evidence';
 import { EVIDENCE_CONFIG } from '../components/evidence/constants';
 import { buildPresignedUrlItems } from '../components/evidence/validate';
+import { fileLastModifiedToISO } from '@/utils/date';
 
 // ─── query key ──────────────────────────────────────────
 
@@ -125,28 +126,48 @@ const fetchAndNormalize: Record<
 const registerByType = async (
   type: EvidenceType,
   complaintId: string,
-  items: { evidenceId: string; filename: string }[],
+  items: { evidenceId: string; filename: string; fileCreatedAt: string }[],
 ) => {
   switch (type) {
     case 'MESSAGE':
       return registerMessages(complaintId, {
-        items: items.map((i) => ({ messageId: i.evidenceId, filename: i.filename })),
+        items: items.map((i) => ({
+          messageId: i.evidenceId,
+          filename: i.filename,
+          fileCreatedAt: i.fileCreatedAt,
+        })),
       });
     case 'VOICE':
       return registerVoices(complaintId, {
-        items: items.map((i) => ({ voiceId: i.evidenceId, filename: i.filename })),
+        items: items.map((i) => ({
+          voiceId: i.evidenceId,
+          filename: i.filename,
+          fileCreatedAt: i.fileCreatedAt,
+        })),
       });
     case 'VICTIM':
       return registerVictims(complaintId, {
-        items: items.map((i) => ({ victimId: i.evidenceId, filename: i.filename })),
+        items: items.map((i) => ({
+          victimId: i.evidenceId,
+          filename: i.filename,
+          fileCreatedAt: i.fileCreatedAt,
+        })),
       });
     case 'REPORT_RECORD':
       return registerReportRecords(complaintId, {
-        items: items.map((i) => ({ reportRecordId: i.evidenceId, filename: i.filename })),
+        items: items.map((i) => ({
+          reportRecordId: i.evidenceId,
+          filename: i.filename,
+          fileCreatedAt: i.fileCreatedAt,
+        })),
       });
     case 'INCIDENT_LOG':
       return registerIncidentLogFiles(complaintId, {
-        items: items.map((i) => ({ incidentLogId: i.evidenceId, filename: i.filename })),
+        items: items.map((i) => ({
+          incidentLogId: i.evidenceId,
+          filename: i.filename,
+          fileCreatedAt: i.fileCreatedAt,
+        })),
       });
   }
 };
@@ -207,9 +228,10 @@ export function useUploadEvidence(complaintId: string | undefined, type: Evidenc
       return registerByType(
         type,
         complaintId!,
-        presignedUrls.map((p) => ({
+        presignedUrls.map((p, i) => ({
           evidenceId: p.evidence_id,
           filename: p.filename,
+          fileCreatedAt: fileLastModifiedToISO(files[i]),
         })),
       );
     },

--- a/src/app/my-space/case/hooks/useTimelineGenerate.ts
+++ b/src/app/my-space/case/hooks/useTimelineGenerate.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from 'react';
+import { useAuthStore } from '@/stores/authStore';
+import type { TimelineProgressData } from '@/types/timeline';
+
+interface UseTimelineGenerateParams {
+  taskId: string | null;
+  onDone: () => void;
+}
+
+interface UseTimelineGenerateResult {
+  progressData: TimelineProgressData | null;
+}
+
+/**
+ * 타임라인 AI 생성 진행률 SSE 훅
+ *
+ * - task_preparing: AI Worker 준비 중 (status: null | PENDING)
+ * - progress: 증거 처리 진행 중 (status: PROCESSING | DONE)
+ * - done: 완료 → onDone 콜백 호출
+ */
+export function useTimelineGenerate({
+  taskId,
+  onDone,
+}: UseTimelineGenerateParams): UseTimelineGenerateResult {
+  const sseBaseUrl = useAuthStore((s) => s.sseBaseUrl);
+  const onDoneRef = useRef(onDone);
+  const [progressData, setProgressData] = useState<TimelineProgressData | null>(null);
+
+  useEffect(() => {
+    onDoneRef.current = onDone;
+  });
+
+  useEffect(() => {
+    if (!taskId || !sseBaseUrl) return;
+
+    const url = `${sseBaseUrl.replace(/\/$/, '')}/api/v1/timeline/${taskId}/progress`;
+    const es = new EventSource(url);
+
+    es.addEventListener('task_preparing', (e) => {
+      setProgressData(JSON.parse((e as MessageEvent).data));
+    });
+
+    es.addEventListener('progress', (e) => {
+      setProgressData(JSON.parse((e as MessageEvent).data));
+    });
+
+    es.addEventListener('done', () => {
+      es.close();
+      onDoneRef.current();
+    });
+
+    es.addEventListener('error', () => {
+      es.close();
+    });
+
+    return () => {
+      es.close();
+      setProgressData(null);
+    };
+  }, [taskId, sseBaseUrl]);
+
+  return { progressData };
+}

--- a/src/app/my-space/case/hooks/useTimelineGenerate.ts
+++ b/src/app/my-space/case/hooks/useTimelineGenerate.ts
@@ -25,13 +25,21 @@ export function useTimelineGenerate({
   const sseBaseUrl = useAuthStore((s) => s.sseBaseUrl);
   const onDoneRef = useRef(onDone);
   const [progressData, setProgressData] = useState<TimelineProgressData | null>(null);
+  const [sseError, setSseError] = useState<Error | null>(null);
+
+  // SSE 에러를 렌더 타임에 throw → ErrorBoundary가 잡음
+  if (sseError) throw sseError;
 
   useEffect(() => {
     onDoneRef.current = onDone;
   });
 
   useEffect(() => {
-    if (!taskId || !sseBaseUrl) return;
+    if (!taskId) return;
+    if (!sseBaseUrl) {
+      setSseError(new Error('SSE_URL_NOT_FOUND'));
+      return;
+    }
 
     const url = `${sseBaseUrl.replace(/\/$/, '')}/api/v1/timeline/${taskId}/progress`;
     const es = new EventSource(url);
@@ -51,6 +59,7 @@ export function useTimelineGenerate({
 
     es.addEventListener('error', () => {
       es.close();
+      setSseError(new Error('SSE_ERROR'));
     });
 
     return () => {

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -67,9 +67,9 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
   const { mutate: save, isPending: isSaving } = useUpdateComplaint(complaintId);
   const [generatingTaskId, setGeneratingTaskId] = useState<string | null>(null);
 
-  // 서버 데이터 → 프론트 step 변환
-  const step: Step = STEP_MAP[complaint.step];
+  // 서버 데이터 → 프론트 step 변환 — 생성 중에는 step 2로 표시
   const isGenerating = complaint.step === 'TIMELINE_GENERATING' || generatingTaskId !== null;
+  const step: Step = isGenerating ? 2 : STEP_MAP[complaint.step];
   const title = complaint.name;
 
   // TIMELINE_GENERATING 재진입 처리 — task_id 조회 후 SSE 연결
@@ -96,8 +96,7 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
       if (step === 1) {
         const { need_to_generate } = await needToGenerateTimeline(complaintId);
         if (need_to_generate) {
-          // TODO: 프로덕션 배포 전 'openAI'로 변경
-          const { task_id } = await requestGenerateTimeline(complaintId, 'mock');
+          const { task_id } = await requestGenerateTimeline(complaintId, 'openAI');
           setGeneratingTaskId(task_id);
           return;
         }
@@ -144,20 +143,21 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
         {/* 4단계 프로그레스 바 */}
         <CaseProgress currentStep={step} />
         {/* 스텝별 컨텐츠 조건부 렌더링 */}
-        {isGenerating ? (
-          <TimelineGeneratingView progressData={progressData} />
-        ) : (
-          <QueryErrorResetBoundary>
-            {({ reset }) => (
-              <ErrorBoundary FallbackComponent={CaseErrorFallback} onReset={reset}>
-                {step === 1 && <StepCollect complaintId={complaintId} />}
-                {step === 2 && <StepTimeline />}
-                {step === 3 && <StepDocument />}
-                {step === 4 && <StepComplete />}
-              </ErrorBoundary>
-            )}
-          </QueryErrorResetBoundary>
-        )}
+        <QueryErrorResetBoundary>
+          {({ reset }) => (
+            <ErrorBoundary FallbackComponent={CaseErrorFallback} onReset={reset}>
+              {step === 1 && <StepCollect complaintId={complaintId} />}
+              {step === 2 &&
+                (isGenerating ? (
+                  <TimelineGeneratingView progressData={progressData} />
+                ) : (
+                  <StepTimeline />
+                ))}
+              {step === 3 && <StepDocument />}
+              {step === 4 && <StepComplete />}
+            </ErrorBoundary>
+          )}
+        </QueryErrorResetBoundary>
       </div>
     </div>
   );

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -4,7 +4,6 @@ import { Suspense, useState, useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useAuthStore } from '@/stores/authStore';
 import { useComplaint, useUpdateComplaint } from './hooks/useComplaint';
-import { useTimelineGenerate } from './hooks/useTimelineGenerate';
 import { needToGenerateTimeline, requestGenerateTimeline, getCurrentTaskId } from '@/api/timeline';
 import { STEP_MAP, STEP_REVERSE_MAP, type Step } from '@/types/complaint';
 import {
@@ -18,6 +17,7 @@ import {
 } from './components';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { CaseErrorFallback } from '@/components/fallbacks/CaseErrorFallback';
+import { TimelineErrorFallback } from '@/components/fallbacks/TimelineErrorFallback';
 import { CasePageSkeleton } from '@/components/skeletons/CasePageSkeleton';
 import { toast } from 'react-toastify';
 
@@ -66,6 +66,7 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
   const { data: complaint } = useComplaint(complaintId);
   const { mutate: save, isPending: isSaving } = useUpdateComplaint(complaintId);
   const [generatingTaskId, setGeneratingTaskId] = useState<string | null>(null);
+  const [isTimelineError, setIsTimelineError] = useState(false);
 
   // 서버 데이터 → 프론트 step 변환 — 생성 중에는 step 2로 표시
   const isGenerating = complaint.step === 'TIMELINE_GENERATING' || generatingTaskId !== null;
@@ -81,14 +82,21 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
     }
   }, [complaint.step, complaintId, generatingTaskId]);
 
-  // SSE 연결 — done 이벤트 시 step TIMELINE으로 저장 → step 2로 이동
-  const { progressData } = useTimelineGenerate({
-    taskId: generatingTaskId,
-    onDone: () => {
-      setGeneratingTaskId(null);
-      save({ step: 'TIMELINE' });
-    },
-  });
+  const handleGenerateDone = () => {
+    setGeneratingTaskId(null);
+    save({ step: 'TIMELINE' });
+  };
+
+  /** 타임라인 생성 재시도 — 새 task_id로 SSE 재연결 */
+  const handleGenerateRetry = async () => {
+    try {
+      const { task_id } = await requestGenerateTimeline(complaintId, 'openAI');
+      setIsTimelineError(false);
+      setGeneratingTaskId(task_id);
+    } catch {
+      toast.error('타임라인 생성 요청에 실패했어요. 다시 시도해주세요.');
+    }
+  };
 
   /** 다음 스텝으로 이동 + 서버 저장 */
   const goNext = async () => {
@@ -110,6 +118,8 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
 
   /** 이전 스텝으로 이동 + 서버 저장 */
   const goPrev = () => {
+    setGeneratingTaskId(null);
+    setIsTimelineError(false);
     const prevStep = clampStep(step - 1);
     save({ step: STEP_REVERSE_MAP[prevStep] });
   };
@@ -135,7 +145,7 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
         isSaveDisabled={step === 1 || isGenerating}
         onPrev={goPrev}
         onNext={goNext}
-        hasPrev={step > MIN_STEP && !isGenerating}
+        hasPrev={step > MIN_STEP && (!isGenerating || isTimelineError)}
         hasNext={step < MAX_STEP && !isGenerating}
         updatedAt={complaint.updated_at}
       />
@@ -149,7 +159,17 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
               {step === 1 && <StepCollect complaintId={complaintId} />}
               {step === 2 &&
                 (isGenerating ? (
-                  <TimelineGeneratingView progressData={progressData} />
+                  // SSE 에러는 TimelineErrorFallback으로 처리 — 헤더 유지
+                  <ErrorBoundary
+                    FallbackComponent={TimelineErrorFallback}
+                    onError={() => setIsTimelineError(true)}
+                    onReset={handleGenerateRetry}
+                  >
+                    <TimelineGeneratingView
+                      taskId={generatingTaskId!}
+                      onDone={handleGenerateDone}
+                    />
+                  </ErrorBoundary>
                 ) : (
                   <StepTimeline />
                 ))}

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '@/stores/authStore';
 import { useComplaint, useUpdateComplaint } from './hooks/useComplaint';
 import { needToGenerateTimeline, requestGenerateTimeline, getCurrentTaskId } from '@/api/timeline';
 import { STEP_MAP, STEP_REVERSE_MAP, type Step } from '@/types/complaint';
+import type { TimelinePhase } from '@/types/timeline';
 import {
   CaseHeader,
   CaseProgress,
@@ -19,7 +20,8 @@ import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { CaseErrorFallback } from '@/components/fallbacks/CaseErrorFallback';
 import { TimelineErrorFallback } from '@/components/fallbacks/TimelineErrorFallback';
 import { CasePageSkeleton } from '@/components/skeletons/CasePageSkeleton';
-import { toast } from 'react-toastify';
+import { Spinner } from '@/components/Spinner';
+import { showAlert } from '@/utils/alert';
 
 const MIN_STEP: Step = 1;
 const MAX_STEP: Step = 4;
@@ -65,36 +67,46 @@ function CasePageGuard() {
 function CasePageContent({ complaintId }: { complaintId: string }) {
   const { data: complaint } = useComplaint(complaintId);
   const { mutate: save, isPending: isSaving } = useUpdateComplaint(complaintId);
-  const [generatingTaskId, setGeneratingTaskId] = useState<string | null>(null);
-  const [isTimelineError, setIsTimelineError] = useState(false);
+  const [phase, setPhase] = useState<TimelinePhase>(
+    complaint.step === 'TIMELINE_GENERATING' ? 'restoring' : 'idle',
+  );
+  const [taskId, setTaskId] = useState<string | null>(null);
 
-  // 서버 데이터 → 프론트 step 변환 — 생성 중에는 step 2로 표시
-  const isGenerating = complaint.step === 'TIMELINE_GENERATING' || generatingTaskId !== null;
-  const step: Step = isGenerating ? 2 : STEP_MAP[complaint.step];
+  // 서버 데이터 → 프론트 step 변환 — 생성 플로우 진입 중에는 step 2로 표시
+  const step: Step = phase !== 'idle' ? 2 : STEP_MAP[complaint.step];
   const title = complaint.name;
 
   // TIMELINE_GENERATING 재진입 처리 — task_id 조회 후 SSE 연결
   useEffect(() => {
-    if (complaint.step === 'TIMELINE_GENERATING' && !generatingTaskId) {
-      getCurrentTaskId(complaintId).then(({ task_id }) => {
-        setGeneratingTaskId(task_id);
+    if (phase !== 'restoring') return;
+    getCurrentTaskId(complaintId)
+      .then(({ task_id }) => {
+        setTaskId(task_id);
+        setPhase('generating');
+      })
+      .catch(() => {
+        setPhase('idle');
+        showAlert.error({
+          title: '타임라인 생성 정보를 불러오는 중 오류가 발생했어요.\n다시 시도해주세요.',
+        });
       });
-    }
-  }, [complaint.step, complaintId, generatingTaskId]);
+  }, [phase, complaintId]);
 
   const handleGenerateDone = () => {
-    setGeneratingTaskId(null);
+    setPhase('idle');
+    setTaskId(null);
     save({ step: 'TIMELINE' });
   };
 
   /** 타임라인 생성 재시도 — 새 task_id로 SSE 재연결 */
   const handleGenerateRetry = async () => {
     try {
+      setPhase('starting');
       const { task_id } = await requestGenerateTimeline(complaintId, 'openAI');
-      setIsTimelineError(false);
-      setGeneratingTaskId(task_id);
+      setTaskId(task_id);
+      setPhase('generating');
     } catch {
-      toast.error('타임라인 생성 요청에 실패했어요. 다시 시도해주세요.');
+      setPhase('error');
     }
   };
 
@@ -105,21 +117,24 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
         const { need_to_generate } = await needToGenerateTimeline(complaintId);
         if (need_to_generate) {
           const { task_id } = await requestGenerateTimeline(complaintId, 'openAI');
-          setGeneratingTaskId(task_id);
+          setTaskId(task_id);
+          setPhase('generating');
           return;
         }
       }
       const nextStep = clampStep(step + 1);
       save({ step: STEP_REVERSE_MAP[nextStep] });
     } catch {
-      toast.error('다음 단계로 이동하는 중 오류가 발생했어요. 다시 시도해주세요.');
+      showAlert.error({
+        title: '다음 단계로 이동하는 중 오류가 발생했어요.\n다시 시도해주세요.',
+      });
     }
   };
 
   /** 이전 스텝으로 이동 + 서버 저장 */
   const goPrev = () => {
-    setGeneratingTaskId(null);
-    setIsTimelineError(false);
+    setPhase('idle');
+    setTaskId(null);
     const prevStep = clampStep(step - 1);
     save({ step: STEP_REVERSE_MAP[prevStep] });
   };
@@ -142,11 +157,11 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
         onTitleChange={handleTitleChange}
         onSave={handleSave}
         isSaving={isSaving}
-        isSaveDisabled={step === 1 || isGenerating}
+        isSaveDisabled={step === 1 || phase !== 'idle'}
         onPrev={goPrev}
         onNext={goNext}
-        hasPrev={step > MIN_STEP && (!isGenerating || isTimelineError)}
-        hasNext={step < MAX_STEP && !isGenerating}
+        hasPrev={step > MIN_STEP && (phase === 'idle' || phase === 'error')}
+        hasNext={step < MAX_STEP && phase === 'idle'}
         updatedAt={complaint.updated_at}
       />
       <div className="space-y-6 p-6">
@@ -158,17 +173,21 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
             <ErrorBoundary FallbackComponent={CaseErrorFallback} onReset={reset}>
               {step === 1 && <StepCollect complaintId={complaintId} />}
               {step === 2 &&
-                (isGenerating ? (
-                  // SSE 에러는 TimelineErrorFallback으로 처리 — 헤더 유지
+                (phase !== 'idle' ? (
+                  // 생성 플로우 — phase !== 'idle'인 동안 ErrorBoundary 유지
                   <ErrorBoundary
                     FallbackComponent={TimelineErrorFallback}
-                    onError={() => setIsTimelineError(true)}
-                    onReset={handleGenerateRetry}
+                    onError={() => setPhase('error')}
+                    onReset={() => {
+                      handleGenerateRetry();
+                    }}
                   >
-                    <TimelineGeneratingView
-                      taskId={generatingTaskId!}
-                      onDone={handleGenerateDone}
-                    />
+                    {phase === 'generating' ? (
+                      <TimelineGeneratingView taskId={taskId!} onDone={handleGenerateDone} />
+                    ) : (
+                      // starting / restoring: taskId 미확보 — 스피너 표시
+                      <Spinner size="lg" className="text-primary mx-auto my-20" />
+                    )}
                   </ErrorBoundary>
                 ) : (
                   <StepTimeline />

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useState, useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useAuthStore } from '@/stores/authStore';
 import { useComplaint, useUpdateComplaint } from './hooks/useComplaint';
+import { useTimelineGenerate } from './hooks/useTimelineGenerate';
+import { needToGenerateTimeline, requestGenerateTimeline, getCurrentTaskId } from '@/api/timeline';
 import { STEP_MAP, STEP_REVERSE_MAP, type Step } from '@/types/complaint';
 import {
   CaseHeader,
@@ -12,10 +14,12 @@ import {
   StepTimeline,
   StepDocument,
   StepComplete,
+  TimelineGeneratingView,
 } from './components';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { CaseErrorFallback } from '@/components/fallbacks/CaseErrorFallback';
 import { CasePageSkeleton } from '@/components/skeletons/CasePageSkeleton';
+import { toast } from 'react-toastify';
 
 const MIN_STEP: Step = 1;
 const MAX_STEP: Step = 4;
@@ -61,15 +65,48 @@ function CasePageGuard() {
 function CasePageContent({ complaintId }: { complaintId: string }) {
   const { data: complaint } = useComplaint(complaintId);
   const { mutate: save, isPending: isSaving } = useUpdateComplaint(complaintId);
+  const [generatingTaskId, setGeneratingTaskId] = useState<string | null>(null);
 
   // 서버 데이터 → 프론트 step 변환
   const step: Step = STEP_MAP[complaint.step];
+  const isGenerating = complaint.step === 'TIMELINE_GENERATING' || generatingTaskId !== null;
   const title = complaint.name;
 
+  // TIMELINE_GENERATING 재진입 처리 — task_id 조회 후 SSE 연결
+  useEffect(() => {
+    if (complaint.step === 'TIMELINE_GENERATING' && !generatingTaskId) {
+      getCurrentTaskId(complaintId).then(({ task_id }) => {
+        setGeneratingTaskId(task_id);
+      });
+    }
+  }, [complaint.step, complaintId, generatingTaskId]);
+
+  // SSE 연결 — done 이벤트 시 step TIMELINE으로 저장 → step 2로 이동
+  const { progressData } = useTimelineGenerate({
+    taskId: generatingTaskId,
+    onDone: () => {
+      setGeneratingTaskId(null);
+      save({ step: 'TIMELINE' });
+    },
+  });
+
   /** 다음 스텝으로 이동 + 서버 저장 */
-  const goNext = () => {
-    const nextStep = clampStep(step + 1);
-    save({ step: STEP_REVERSE_MAP[nextStep] });
+  const goNext = async () => {
+    try {
+      if (step === 1) {
+        const { need_to_generate } = await needToGenerateTimeline(complaintId);
+        if (need_to_generate) {
+          // TODO: 프로덕션 배포 전 'openAI'로 변경
+          const { task_id } = await requestGenerateTimeline(complaintId, 'mock');
+          setGeneratingTaskId(task_id);
+          return;
+        }
+      }
+      const nextStep = clampStep(step + 1);
+      save({ step: STEP_REVERSE_MAP[nextStep] });
+    } catch {
+      toast.error('다음 단계로 이동하는 중 오류가 발생했어요. 다시 시도해주세요.');
+    }
   };
 
   /** 이전 스텝으로 이동 + 서버 저장 */
@@ -96,27 +133,31 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
         onTitleChange={handleTitleChange}
         onSave={handleSave}
         isSaving={isSaving}
-        isSaveDisabled={step === 1}
+        isSaveDisabled={step === 1 || isGenerating}
         onPrev={goPrev}
         onNext={goNext}
-        hasPrev={step > MIN_STEP}
-        hasNext={step < MAX_STEP}
+        hasPrev={step > MIN_STEP && !isGenerating}
+        hasNext={step < MAX_STEP && !isGenerating}
         updatedAt={complaint.updated_at}
       />
       <div className="space-y-6 p-6">
         {/* 4단계 프로그레스 바 */}
         <CaseProgress currentStep={step} />
         {/* 스텝별 컨텐츠 조건부 렌더링 */}
-        <QueryErrorResetBoundary>
-          {({ reset }) => (
-            <ErrorBoundary FallbackComponent={CaseErrorFallback} onReset={reset}>
-              {step === 1 && <StepCollect complaintId={complaintId} />}
-              {step === 2 && <StepTimeline />}
-              {step === 3 && <StepDocument />}
-              {step === 4 && <StepComplete />}
-            </ErrorBoundary>
-          )}
-        </QueryErrorResetBoundary>
+        {isGenerating ? (
+          <TimelineGeneratingView progressData={progressData} />
+        ) : (
+          <QueryErrorResetBoundary>
+            {({ reset }) => (
+              <ErrorBoundary FallbackComponent={CaseErrorFallback} onReset={reset}>
+                {step === 1 && <StepCollect complaintId={complaintId} />}
+                {step === 2 && <StepTimeline />}
+                {step === 3 && <StepDocument />}
+                {step === 4 && <StepComplete />}
+              </ErrorBoundary>
+            )}
+          </QueryErrorResetBoundary>
+        )}
       </div>
     </div>
   );

--- a/src/components/AlertCard.tsx
+++ b/src/components/AlertCard.tsx
@@ -25,7 +25,7 @@ export function AlertCard({ variant, title, description, onClose }: AlertCardPro
     <div className="flex w-full items-start gap-3 rounded-lg bg-white p-4">
       <Image src={icon} alt="" width={24} height={24} className="shrink-0" />
       <div className="flex-1 space-y-0.5">
-        <p className="typo-heading-4 text-gray-900">{title}</p>
+        <p className="typo-heading-4 whitespace-pre-line text-gray-900">{title}</p>
         {description && (
           <p className="typo-body-7 whitespace-pre-line text-gray-500">{description}</p>
         )}

--- a/src/components/fallbacks/TimelineErrorFallback.tsx
+++ b/src/components/fallbacks/TimelineErrorFallback.tsx
@@ -1,0 +1,14 @@
+import type { FallbackProps } from 'react-error-boundary';
+import { Button } from '@/components/ui/button';
+
+export function TimelineErrorFallback({ resetErrorBoundary }: FallbackProps) {
+  return (
+    <div className="flex flex-col items-center gap-2 py-20">
+      <p className="typo-heading-3 text-gray-800">타임라인 생성에 실패했습니다</p>
+      <p className="typo-body-7 mb-6 text-gray-500">아래 버튼을 통해 다시 시도해주세요</p>
+      <Button onClick={resetErrorBoundary} size="lg" className="text-white">
+        다시 실행하기
+      </Button>
+    </div>
+  );
+}

--- a/src/components/providers/AuthProvider.tsx
+++ b/src/components/providers/AuthProvider.tsx
@@ -17,6 +17,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const initAuth = useAuthStore((state) => state.initAuth);
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const fetchUser = useAuthStore((state) => state.fetchUser);
+  const fetchSseServerUrl = useAuthStore((state) => state.fetchSseServerUrl);
 
   useEffect(() => {
     initAuth();
@@ -26,8 +27,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     if (isLoggedIn) {
       console.log('[AuthProvider] isLoggedIn=true → fetchUser 호출');
       fetchUser();
+      fetchSseServerUrl();
     }
-  }, [isLoggedIn, fetchUser]);
+  }, [isLoggedIn, fetchUser, fetchSseServerUrl]);
 
   return <>{children}</>;
 }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { authCookies } from '@/utils/auth';
 import { axiosInstance } from '@/api/axiosInstance';
+import { getSseServerUrl } from '@/api/timeline';
 import { create } from 'zustand';
 
 export interface User {
@@ -16,17 +17,20 @@ interface AuthState {
   isLoggedIn: boolean;
   isAuthInitialized: boolean;
   user: User | null;
+  sseBaseUrl: string | null;
 
   login: (accessToken: string, refreshToken: string, idToken: string) => void;
   logout: () => void;
   initAuth: () => void;
   fetchUser: () => Promise<void>;
+  fetchSseServerUrl: () => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
   isLoggedIn: false,
   isAuthInitialized: false,
   user: null,
+  sseBaseUrl: null,
 
   login: (accessToken, refreshToken, idToken) => {
     authCookies.setTokens(accessToken, refreshToken, idToken);
@@ -35,7 +39,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   logout: () => {
     authCookies.clearTokens();
-    set({ isLoggedIn: false, user: null });
+    set({ isLoggedIn: false, user: null, sseBaseUrl: null });
   },
 
   initAuth: () => {
@@ -54,6 +58,15 @@ export const useAuthStore = create<AuthState>((set) => ({
     } catch (err) {
       console.error('[AuthStore] fetchUser 실패:', err);
       set({ user: null });
+    }
+  },
+
+  fetchSseServerUrl: async () => {
+    try {
+      const { base_url } = await getSseServerUrl();
+      set({ sseBaseUrl: base_url });
+    } catch (err) {
+      console.error('[AuthStore] fetchSseServerUrl 실패:', err);
     }
   },
 }));

--- a/src/types/complaint.ts
+++ b/src/types/complaint.ts
@@ -1,5 +1,10 @@
 /** 백엔드 step 값 */
-export type ComplaintStep = 'EVIDENCE' | 'TIMELINE' | 'DOCUMENT' | 'COMPLETE';
+export type ComplaintStep =
+  | 'EVIDENCE'
+  | 'TIMELINE_GENERATING'
+  | 'TIMELINE'
+  | 'DOCUMENT'
+  | 'COMPLETE';
 
 /** 프론트 step 값 (1~4) */
 export type Step = 1 | 2 | 3 | 4;
@@ -20,9 +25,10 @@ export type UpdateComplaintPayload = {
   step?: ComplaintStep;
 };
 
-/** step 변환 맵 */
+/** step 변환 맵 — TIMELINE_GENERATING은 프론트에서 step 1로 표시 (생성 중 UI) */
 export const STEP_MAP: Record<ComplaintStep, Step> = {
   EVIDENCE: 1,
+  TIMELINE_GENERATING: 1,
   TIMELINE: 2,
   DOCUMENT: 3,
   COMPLETE: 4,

--- a/src/types/complaint.ts
+++ b/src/types/complaint.ts
@@ -25,10 +25,10 @@ export type UpdateComplaintPayload = {
   step?: ComplaintStep;
 };
 
-/** step 변환 맵 — TIMELINE_GENERATING은 프론트에서 step 1로 표시 (생성 중 UI) */
+/** step 변환 맵 — TIMELINE_GENERATING은 프론트에서 step 2로 표시 (생성 중 UI) */
 export const STEP_MAP: Record<ComplaintStep, Step> = {
   EVIDENCE: 1,
-  TIMELINE_GENERATING: 1,
+  TIMELINE_GENERATING: 2,
   TIMELINE: 2,
   DOCUMENT: 3,
   COMPLETE: 4,

--- a/src/types/evidence.ts
+++ b/src/types/evidence.ts
@@ -53,6 +53,7 @@ export type UpdateEvidenceFilenameResponse = {
 export type MessageRegisterItem = {
   messageId: string;
   filename: string;
+  fileCreatedAt: string; // ISO 8601 — file.lastModified 변환값
 };
 
 export type MessageRegisterRequest = {
@@ -113,6 +114,7 @@ export type MessageOriginal = {
 export type VoiceRegisterItem = {
   voiceId: string;
   filename: string;
+  fileCreatedAt: string;
 };
 
 export type VoiceRegisterRequest = {
@@ -172,6 +174,7 @@ export type VoiceOriginal = {
 export type VictimRegisterItem = {
   victimId: string;
   filename: string;
+  fileCreatedAt: string;
 };
 
 export type VictimRegisterRequest = {
@@ -232,6 +235,7 @@ export type VictimOriginal = {
 export type ReportRecordRegisterItem = {
   reportRecordId: string;
   filename: string;
+  fileCreatedAt: string;
 };
 
 export type ReportRecordRegisterRequest = {
@@ -292,6 +296,7 @@ export type IncidentLogType = 'FILE' | 'FORM_DATA';
 export type IncidentLogFileRegisterItem = {
   incidentLogId: string;
   filename: string;
+  fileCreatedAt: string;
 };
 
 export type IncidentLogFileRegisterRequest = {

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -161,3 +161,29 @@ export type DeleteManualReferencedEvidencesRequest = {
 export type TimelineDownloadResponse = {
   download_url: string;
 };
+
+// ─── AI 생성 ─────────────────────────────────────────────
+
+export type NeedToGenerateResponse = {
+  need_to_generate: boolean;
+};
+
+export type RequestGenerateResponse = {
+  task_id: string;
+};
+
+export type CurrentTaskIdResponse = {
+  task_id: string;
+};
+
+export type SseServerUrlResponse = {
+  base_url: string;
+};
+
+export type TimelineProgressEvent = 'task_preparing' | 'progress' | 'done';
+
+export type TimelineProgressData = {
+  status: 'PENDING' | 'PROCESSING' | 'DONE' | null;
+  processed: number | null;
+  total: number | null;
+};

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -162,6 +162,10 @@ export type TimelineDownloadResponse = {
   download_url: string;
 };
 
+// ─── AI 생성 phase ───────────────────────────────────────
+
+export type TimelinePhase = 'idle' | 'starting' | 'restoring' | 'generating' | 'error';
+
 // ─── AI 생성 ─────────────────────────────────────────────
 
 export type NeedToGenerateResponse = {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -30,6 +30,15 @@ export function parseBirthdate(value: string | undefined): Date | undefined {
 }
 
 /**
+ * File의 lastModified 타임스탬프를 ISO 8601 문자열로 변환
+ *
+ * @param file - 변환할 File 객체
+ */
+export function fileLastModifiedToISO(file: File): string {
+  return new Date(file.lastModified).toISOString();
+}
+
+/**
  * 숫자 입력을 YYYY-MM-DD 형식으로 자동 포맷
  */
 export function formatBirthdateInput(value: string): string {


### PR DESCRIPTION
## 작업 내용

### 개요
Step 1(증거 수집) → Step 2(타임라인) 전환 시 AI가 증거를 분석해 타임라인을 자동 생성하는 플로우를 구현했습니다. SSE(Server-Sent Events)로 진행률을 실시간 스트리밍하며, 완료되면 Step 2 타임라인 뷰로 진입합니다.

### AI 생성 플로우
- 다음 버튼 클릭 시 `needToGenerateTimeline`으로 생성 필요 여부 확인
- 필요한 경우 `requestGenerateTimeline`으로 task_id 발급 후 생성 화면으로 전환
- SSE(`EventSource`)로 `task_preparing` / `progress` / `done` / `error` 이벤트 수신
- `done` 이벤트 수신 시 step TIMELINE 저장 후 타임라인 뷰 진입
- 페이지 새로고침 또는 재진입 시 `getCurrentTaskId`로 기존 task_id 복구 후 SSE 재연결

### 진행률 UI (`TimelineGeneratingView`)
- 준비(PENDING) / 처리 중(PROCESSING) / 마무리(DONE) 3단계 프로그레스 바
- 처리 중 단계에서 `processed / total` 기반으로 바 채움 비율 표시
- SSE 이벤트 수신 전 스피너 표시

### `TimelinePhase` 상태 머신
기존 `isGenerating` + `isTimelineError` boolean 조합은 세 가지 문제가 있었습니다.
1. SSE 에러 발생 후 `generatingTaskId`를 초기화하면 ErrorBoundary가 unmount되어 에러 UI가 사라짐 → `isTimelineError`를 별도로 두는 임시방편 필요
2. ErrorBoundary의 `onError` 타이밍 문제로 `onMount` + `useEffect` 우회 방식 사용
3. `isGenerating`은 task_id 획득 이후에만 true가 되어 API 호출 중 에러를 처리할 수 없음

이를 `TimelinePhase` 단일 상태로 교체해 해결했습니다.

| phase | 의미 |
|---|---|
| `idle` | 생성 플로우 진입 전 |
| `starting` | 다음 버튼 클릭 후 API 호출 중 |
| `restoring` | 재진입 시 `getCurrentTaskId` 호출 중 |
| `generating` | SSE 연결 및 생성 진행 중 |
| `error` | 생성 실패, `TimelineErrorFallback` 표시 중 |

- `useState` 초기값에서 `complaint.step === 'TIMELINE_GENERATING'`이면 `restoring`으로 설정
- `useEffect`는 `phase === 'restoring'`일 때만 API 호출, 다른 역할 없음
- ErrorBoundary 마운트 조건을 `phase !== 'idle'`로 통일해 unmount 문제 해결
- `onError`에서 `setPhase('error')` 직접 호출, `onMount` 핵 제거

### 에러 처리 정책

| 단계 | 에러 | 처리 |
|---|---|---|
| `starting` / `restoring` | API 실패 | toast, step 1 유지 |
| `generating` | SSE 에러 | ErrorBoundary → `TimelineErrorFallback` |
| `starting` (재시도) | API 실패 | phase → `error` 유지 |

- 에러 시 이전 버튼 활성화(`phase === 'error'`)
- AI 생성 중(`starting` / `restoring` / `generating`) 저장·이전·다음 버튼 전체 비활성화
- 재시도 시 task_id를 null로 거치지 않고 새 task_id로 직접 교체 (재진입 useEffect 루프 방지)

## 이슈 번호
close #53 
## 스크린샷 (선택)

### 준비중
<img width="1628" height="824" alt="스크린샷 2026-04-15 165505" src="https://github.com/user-attachments/assets/257a59e6-c393-4f28-8f28-4490ca9c56f3" />
<img width="750" height="521" alt="스크린샷 2026-04-15 165527" src="https://github.com/user-attachments/assets/dd7aec27-7f78-4510-a4ef-2b1f266bf9b3" />

### 처리중
<img width="1467" height="850" alt="스크린샷 2026-04-15 170645" src="https://github.com/user-attachments/assets/884ddc96-8785-4dda-9f2a-675c20e737d7" />
<img width="701" height="473" alt="스크린샷 2026-04-15 170659" src="https://github.com/user-attachments/assets/1f0db12e-a020-4446-bb16-50ed7f4dca35" />

### 에러 (스크린샷과 다르게 이전 버튼이 활성화 됩니다)
<img width="1885" height="1345" alt="스크린샷 2026-04-09 195641" src="https://github.com/user-attachments/assets/3c0217a3-1c06-4d7e-a6eb-5240c21af4b2" />
