### PR TITLE
[FEAT][#58]: step3 고소장 API 연동 및 유효성 검사 구현

### DIFF
--- a/src/api/document.ts
+++ b/src/api/document.ts
@@ -33,14 +33,16 @@ export async function requestGenerateDocument(
 
 /** 고소장 폼 데이터 조회 */
 export async function getDocument(complaintId: string) {
-  const res = await axiosInstance.get<DocumentFormValues>(`/api/v1/${complaintId}/document`);
+  const res = await axiosInstance.get<DocumentFormValues>(
+    `/api/v1/${complaintId}/document/complaint-form-data`,
+  );
   return res.data;
 }
 
 /** 고소장 폼 데이터 부분 수정 */
 export async function patchDocument(complaintId: string, payload: PatchDocumentPayload) {
   const res = await axiosInstance.patch<DocumentFormValues>(
-    `/api/v1/${complaintId}/document`,
+    `/api/v1/${complaintId}/document/complaint-form-data`,
     payload,
   );
   return res.data;

--- a/src/api/document.ts
+++ b/src/api/document.ts
@@ -1,0 +1,47 @@
+import { axiosInstance } from './axiosInstance';
+import type {
+  DocumentFormValues,
+  NeedToGenerateDocumentResponse,
+  PatchDocumentPayload,
+  RequestGenerateDocumentResponse,
+} from '@/types/document';
+
+// ─── AI 생성 ─────────────────────────────────────────────
+
+/** 고소장 생성 필요 여부 확인 */
+export async function needToGenerateDocument(complaintId: string) {
+  const res = await axiosInstance.get<NeedToGenerateDocumentResponse>(
+    `/api/v1/${complaintId}/ai/document/need-to-generate`,
+  );
+  return res.data;
+}
+
+/** AI 고소장 생성 요청 */
+export async function requestGenerateDocument(
+  complaintId: string,
+  llmType: 'mock' | 'openAI' = 'mock',
+) {
+  const res = await axiosInstance.post<RequestGenerateDocumentResponse>(
+    `/api/v1/${complaintId}/ai/document/request/generate`,
+    {},
+    { params: { llm_type: llmType } },
+  );
+  return res.data;
+}
+
+// ─── 고소장 조회 / 수정 ───────────────────────────────────
+
+/** 고소장 폼 데이터 조회 */
+export async function getDocument(complaintId: string) {
+  const res = await axiosInstance.get<DocumentFormValues>(`/api/v1/${complaintId}/document`);
+  return res.data;
+}
+
+/** 고소장 폼 데이터 부분 수정 */
+export async function patchDocument(complaintId: string, payload: PatchDocumentPayload) {
+  const res = await axiosInstance.patch<DocumentFormValues>(
+    `/api/v1/${complaintId}/document`,
+    payload,
+  );
+  return res.data;
+}

--- a/src/app/my-space/case/components/CaseHeader.tsx
+++ b/src/app/my-space/case/components/CaseHeader.tsx
@@ -26,6 +26,8 @@ interface CaseHeaderProps {
   hasPrev: boolean;
   /** 다음 버튼 활성화 여부 (step 4이면 false) */
   hasNext: boolean;
+  /** 다음 버튼 로딩 상태 */
+  isNextLoading?: boolean;
 }
 
 /**
@@ -45,6 +47,7 @@ export function CaseHeader({
   onNext,
   hasPrev,
   hasNext,
+  isNextLoading = false,
 }: CaseHeaderProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(title);
@@ -119,7 +122,13 @@ export function CaseHeader({
         <Button color="secondary" size="lg" onClick={onPrev} disabled={!hasPrev || isSaving}>
           이전
         </Button>
-        <Button color="primary" size="lg" onClick={onNext} disabled={!hasNext || isSaving}>
+        <Button
+          color="primary"
+          size="lg"
+          onClick={onNext}
+          disabled={!hasNext || isSaving || isNextLoading}
+          loading={isNextLoading}
+        >
           다음 단계로
         </Button>
       </div>

--- a/src/app/my-space/case/components/StepDocument.tsx
+++ b/src/app/my-space/case/components/StepDocument.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { forwardRef, useImperativeHandle, useCallback, useRef, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { TabsList } from '@/components/ui/tabs';
 import { AppTabs, AppTabsTrigger, AppTabsContent } from '@/components/AppTabs';
@@ -14,13 +15,70 @@ import { ContentBlock } from './document/ContentBlock';
 import { SubmissionFooter } from './document/SubmissionFooter';
 import type { DocumentFormValues } from '@/types/document';
 import { useGetDocument } from '../hooks/useDocument';
+import { usePatchDocument } from '../hooks/useDocument';
 
-export function StepDocument({ complaintId }: { complaintId: string }) {
-  const { data: document } = useGetDocument(complaintId);
+export type StepDocumentHandle = {
+  submit: () => void;
+  save: () => Promise<void>;
+  isDirty: () => boolean;
+};
 
-  const { register, watch, control } = useForm<DocumentFormValues>({
-    defaultValues: document,
+interface Props {
+  complaintId: string;
+  onValidSubmit: (values: DocumentFormValues) => void;
+}
+
+export const StepDocument = forwardRef<StepDocumentHandle, Props>(function StepDocument(
+  { complaintId, onValidSubmit },
+  ref,
+) {
+  const { data: documentData } = useGetDocument(complaintId);
+  const { mutateAsync: saveDocument } = usePatchDocument(complaintId);
+
+  const {
+    register,
+    watch,
+    control,
+    handleSubmit,
+    getValues,
+    formState: { errors, dirtyFields },
+  } = useForm<DocumentFormValues>({
+    defaultValues: documentData,
   });
+
+  const dirtyFieldsRef = useRef(dirtyFields);
+  useEffect(() => {
+    dirtyFieldsRef.current = dirtyFields;
+  });
+
+  const onInvalid = useCallback(() => {
+    window.document
+      .querySelector('[aria-invalid="true"]')
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, []);
+
+  const onValid = useCallback(
+    (values: DocumentFormValues) => {
+      onValidSubmit(values);
+    },
+    [onValidSubmit],
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      submit: () => handleSubmit(onValid, onInvalid)(),
+      isDirty: () => Object.keys(dirtyFieldsRef.current).length > 0,
+      save: async () => {
+        const values = getValues();
+        const payload = (
+          Object.keys(dirtyFieldsRef.current) as (keyof DocumentFormValues)[]
+        ).reduce((acc, key) => ({ ...acc, [key]: values[key] }), {} as Partial<DocumentFormValues>);
+        if (Object.keys(payload).length > 0) await saveDocument(payload);
+      },
+    }),
+    [handleSubmit, onValid, onInvalid, saveDocument, getValues],
+  );
 
   return (
     <AppTabs defaultValue="complaint">
@@ -45,8 +103,8 @@ export function StepDocument({ complaintId }: { complaintId: string }) {
 
           {/* 폼 섹션 목록 */}
           <div className="flex flex-col gap-10 px-10 py-10">
-            <ComplainantForm register={register} watch={watch} control={control} />
-            <DefendantForm register={register} watch={watch} control={control} />
+            <ComplainantForm register={register} watch={watch} control={control} errors={errors} />
+            <DefendantForm register={register} watch={watch} control={control} errors={errors} />
             <ComplaintPurposeSection />
             <TextareaSection
               title="4. 범죄 사실"
@@ -55,6 +113,11 @@ export function StepDocument({ complaintId }: { complaintId: string }) {
               placeholder="범죄 사실을 입력하세요"
               fieldName="section_4_crime_facts.content"
               register={register}
+              rules={{
+                required: '범죄사실 내용을 입력해주세요',
+                validate: (v: unknown) => !!(v as string)?.trim() || '범죄사실 내용을 입력해주세요',
+              }}
+              error={errors.section_4_crime_facts?.content}
             />
             <TextareaSection
               title="5. 고소 이유"
@@ -66,7 +129,7 @@ export function StepDocument({ complaintId }: { complaintId: string }) {
             <EvidenceSection
               control={control}
               watch={watch}
-              evidenceList={document.section_6_evidence.evidence_list_text}
+              evidenceList={documentData.section_6_evidence.evidence_list_text}
             />
             <RelatedCasesSection control={control} />
 
@@ -83,9 +146,9 @@ export function StepDocument({ complaintId }: { complaintId: string }) {
             </SectionBlock>
 
             <SubmissionFooter
-              accuserName={document.submission_footer.accuser_name}
-              submitterName={document.submission_footer.submitter_name}
-              policeStation={document.submission_footer.submission_target_police_station}
+              accuserName={documentData.submission_footer.accuser_name}
+              submitterName={documentData.submission_footer.submitter_name}
+              policeStation={documentData.submission_footer.submission_target_police_station}
             />
           </div>
         </div>
@@ -99,4 +162,4 @@ export function StepDocument({ complaintId }: { complaintId: string }) {
       </AppTabsContent>
     </AppTabs>
   );
-}
+});

--- a/src/app/my-space/case/components/StepDocument.tsx
+++ b/src/app/my-space/case/components/StepDocument.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { useForm } from 'react-hook-form';
-import ExternalLinkIcon from '@/assets/icons/external-link.svg';
 import { TabsList } from '@/components/ui/tabs';
 import { AppTabs, AppTabsTrigger, AppTabsContent } from '@/components/AppTabs';
-import { Button } from '@/components/Button';
 import { ComplainantForm } from './document/ComplainantForm';
 import { DefendantForm } from './document/DefendantForm';
 import { ComplaintPurposeSection } from './document/ComplaintPurposeSection';
@@ -16,17 +14,13 @@ import { ContentBlock } from './document/ContentBlock';
 import { SubmissionFooter } from './document/SubmissionFooter';
 import type { DocumentFormValues } from '@/types/document';
 import { useGetDocument } from '../hooks/useDocument';
-import { usePatchDocument } from '../hooks/useDocument';
 
 export function StepDocument({ complaintId }: { complaintId: string }) {
   const { data: document } = useGetDocument(complaintId);
-  const { mutate: saveDocument, isPending: isSaving } = usePatchDocument(complaintId);
 
-  const { register, watch, control, handleSubmit } = useForm<DocumentFormValues>({
+  const { register, watch, control } = useForm<DocumentFormValues>({
     defaultValues: document,
   });
-
-  const onSave = (values: DocumentFormValues) => saveDocument(values);
 
   return (
     <AppTabs defaultValue="complaint">
@@ -36,15 +30,6 @@ export function StepDocument({ complaintId }: { complaintId: string }) {
           <AppTabsTrigger value="complaint">고소장</AppTabsTrigger>
           <AppTabsTrigger value="statement">진술서</AppTabsTrigger>
         </TabsList>
-        <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm">
-            <ExternalLinkIcon />
-            미리보기
-          </Button>
-          <Button size="sm" onClick={handleSubmit(onSave)} loading={isSaving}>
-            저장
-          </Button>
-        </div>
       </div>
 
       {/* 고소장 탭 */}
@@ -97,7 +82,11 @@ export function StepDocument({ complaintId }: { complaintId: string }) {
               </ContentBlock>
             </SectionBlock>
 
-            <SubmissionFooter />
+            <SubmissionFooter
+              accuserName={document.submission_footer.accuser_name}
+              submitterName={document.submission_footer.submitter_name}
+              policeStation={document.submission_footer.submission_target_police_station}
+            />
           </div>
         </div>
       </AppTabsContent>

--- a/src/app/my-space/case/components/StepDocument.tsx
+++ b/src/app/my-space/case/components/StepDocument.tsx
@@ -14,12 +14,19 @@ import { RelatedCasesSection } from './document/RelatedCasesSection';
 import { SectionBlock } from './document/SectionBlock';
 import { ContentBlock } from './document/ContentBlock';
 import { SubmissionFooter } from './document/SubmissionFooter';
-import { type DocumentFormValues, defaultDocumentValues } from '@/types/document';
+import type { DocumentFormValues } from '@/types/document';
+import { useGetDocument } from '../hooks/useDocument';
+import { usePatchDocument } from '../hooks/useDocument';
 
-export function StepDocument() {
-  const { register, watch, control } = useForm<DocumentFormValues>({
-    defaultValues: defaultDocumentValues,
+export function StepDocument({ complaintId }: { complaintId: string }) {
+  const { data: document } = useGetDocument(complaintId);
+  const { mutate: saveDocument, isPending: isSaving } = usePatchDocument(complaintId);
+
+  const { register, watch, control, handleSubmit } = useForm<DocumentFormValues>({
+    defaultValues: document,
   });
+
+  const onSave = (values: DocumentFormValues) => saveDocument(values);
 
   return (
     <AppTabs defaultValue="complaint">
@@ -29,6 +36,15 @@ export function StepDocument() {
           <AppTabsTrigger value="complaint">고소장</AppTabsTrigger>
           <AppTabsTrigger value="statement">진술서</AppTabsTrigger>
         </TabsList>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm">
+            <ExternalLinkIcon />
+            미리보기
+          </Button>
+          <Button size="sm" onClick={handleSubmit(onSave)} loading={isSaving}>
+            저장
+          </Button>
+        </div>
       </div>
 
       {/* 고소장 탭 */}
@@ -62,7 +78,11 @@ export function StepDocument() {
               fieldName="section_5_complaint_reason.content"
               register={register}
             />
-            <EvidenceSection control={control} watch={watch} />
+            <EvidenceSection
+              control={control}
+              watch={watch}
+              evidenceList={document.section_6_evidence.evidence_list_text}
+            />
             <RelatedCasesSection control={control} />
 
             {/* 8. 기타 */}

--- a/src/app/my-space/case/components/document/ComplainantForm.tsx
+++ b/src/app/my-space/case/components/document/ComplainantForm.tsx
@@ -3,23 +3,33 @@
 import { FormTable } from './FormTable';
 import { SectionBlock } from './SectionBlock';
 import type { DocumentFormValues, FormTableProps, RowConfig } from '@/types/document';
+import { requiredText } from '@/types/document';
 
-const ROWS: RowConfig[] = [
+const ROWS: RowConfig<DocumentFormValues>[] = [
   {
     cells: [
       { type: 'label', text: '성 명', subText: '( 상호·대표자 )' },
-      { name: 'section_1_complainant.name_or_company', placeholder: '고소인의 성명을 입력하세요' },
+      {
+        name: 'section_1_complainant.name_or_company',
+        placeholder: '고소인의 성명을 입력하세요',
+        rules: requiredText,
+      },
       { type: 'label', text: '주민등록번호', subText: '( 법인등록번호 )' },
       {
         name: 'section_1_complainant.resident_or_corp_registration_number',
         placeholder: '0000000-0000000',
+        rules: requiredText,
       },
     ],
   },
   {
     cells: [
       { type: 'label', text: '주 소', subText: '( 주사무소 소재지 )' },
-      { name: 'section_1_complainant.address', placeholder: '(현 거주지) 주소를 입력해주세요' },
+      {
+        name: 'section_1_complainant.address',
+        placeholder: '(현 거주지) 주소를 입력해주세요',
+        rules: requiredText,
+      },
     ],
   },
   {
@@ -28,6 +38,7 @@ const ROWS: RowConfig[] = [
       {
         name: 'section_1_complainant.occupation',
         placeholder: "직업 혹은 '무직'을 입력해주세요",
+        rules: requiredText,
       },
       { type: 'label', text: '사무실 주소' },
       {
@@ -43,6 +54,7 @@ const ROWS: RowConfig[] = [
         name: 'section_1_complainant.contact.mobile',
         placeholder: '010-0000-0000',
         prefix: '휴대폰',
+        rules: requiredText,
       },
       { name: 'section_1_complainant.contact.home', placeholder: '02-0000-0000', prefix: '자택' },
       {
@@ -55,7 +67,11 @@ const ROWS: RowConfig[] = [
   {
     cells: [
       { type: 'label', text: '이메일' },
-      { name: 'section_1_complainant.email', placeholder: 'ansimon@gmail.com' },
+      {
+        name: 'section_1_complainant.email',
+        placeholder: 'ansimon@gmail.com',
+        rules: requiredText,
+      },
     ],
   },
   {
@@ -90,13 +106,19 @@ const ROWS: RowConfig[] = [
   },
 ];
 
-type Props = Pick<FormTableProps<DocumentFormValues>, 'register' | 'watch' | 'control'>;
+type Props = Pick<FormTableProps<DocumentFormValues>, 'register' | 'watch' | 'control' | 'errors'>;
 
-export function ComplainantForm({ register, watch, control }: Props) {
+export function ComplainantForm({ register, watch, control, errors }: Props) {
   return (
     <SectionBlock title="1. 고소인" required>
       <div className="flex flex-col gap-2">
-        <FormTable rows={ROWS} register={register} watch={watch} control={control} />
+        <FormTable
+          rows={ROWS}
+          register={register}
+          watch={watch}
+          control={control}
+          errors={errors}
+        />
         <p className="typo-body-7 text-gray-400">
           ※ 고소인이 법인 또는 단체인 경우에는 상호 또는 단체명, 대표자, 법인등록번호(또는
           사업자등록번호), 주된 사무소의 소재지, 전화 등 연락처를 기재하여야 한다. 법인의 경우에는

--- a/src/app/my-space/case/components/document/DefendantForm.tsx
+++ b/src/app/my-space/case/components/document/DefendantForm.tsx
@@ -4,7 +4,24 @@ import { FormTable } from './FormTable';
 import { SectionBlock } from './SectionBlock';
 import type { DocumentFormValues, FormTableProps, RowConfig } from '@/types/document';
 
-const ROWS: RowConfig[] = [
+const isBlank = (value?: string | null) => !value || value.trim() === '';
+
+const isSection2Empty = (formValues: DocumentFormValues) => {
+  const a = formValues.section_2_accused;
+  return [
+    a.name,
+    a.resident_registration_number,
+    a.address,
+    a.occupation,
+    a.office_address,
+    a.email,
+    a.contact?.mobile,
+    a.contact?.home,
+    a.contact?.office,
+  ].every(isBlank);
+};
+
+const ROWS: RowConfig<DocumentFormValues>[] = [
   {
     cells: [
       { type: 'label', text: '성 명' },
@@ -50,18 +67,33 @@ const ROWS: RowConfig[] = [
   {
     cells: [
       { type: 'label', text: '기타사항' },
-      { name: 'section_2_accused.other_details', placeholder: '특징 기재' },
+      {
+        name: 'section_2_accused.other_details',
+        placeholder: '특징 기재',
+        rules: {
+          validate: (value: string | null, formValues: DocumentFormValues) => {
+            if (!isSection2Empty(formValues)) return true;
+            return !isBlank(value) || '피고소인 정보가 없을 경우 기타사항을 입력해주세요';
+          },
+        },
+      },
     ],
   },
 ];
 
-type Props = Pick<FormTableProps<DocumentFormValues>, 'register' | 'watch' | 'control'>;
+type Props = Pick<FormTableProps<DocumentFormValues>, 'register' | 'watch' | 'control' | 'errors'>;
 
-export function DefendantForm({ register, watch, control }: Props) {
+export function DefendantForm({ register, watch, control, errors }: Props) {
   return (
     <SectionBlock title="2. 피고소인" required>
       <div className="flex flex-col gap-2">
-        <FormTable rows={ROWS} register={register} watch={watch} control={control} />
+        <FormTable
+          rows={ROWS}
+          register={register}
+          watch={watch}
+          control={control}
+          errors={errors}
+        />
         <p className="typo-body-7 text-gray-400">
           ※ 기타사항에는 고소인의 관계 및 피고소인의 인적사항과 연락처를 정확히 알 수 없을 경우
           피고소인의 성별, 특징적 외모, 인상착의 등으로 기재하시기 바랍니다.

--- a/src/app/my-space/case/components/document/EvidenceSection.tsx
+++ b/src/app/my-space/case/components/document/EvidenceSection.tsx
@@ -10,19 +10,11 @@ import type { DocumentFormValues } from '@/types/document';
 interface Props {
   control: Control<DocumentFormValues>;
   watch: UseFormWatch<DocumentFormValues>;
+  evidenceList: string[];
 }
 
-export function EvidenceSection({ control, watch }: Props) {
+export function EvidenceSection({ control, watch, evidenceList }: Props) {
   const hasEvidence = watch('section_6_evidence.has_evidence_beyond_statement');
-  // TODO: API 연결 후 watch('section_6_evidence.evidence_list_text')로 교체
-  const evidenceList = [
-    '문자 메시지 캡처 화면 (2024.12.15 - 2024.12.20, 총 23건)',
-    '카카오톡 대화 내역 (2024.12.20, 3건)',
-    '음성사서함 녹음 파일 (2024.12.18, 1건)',
-    '미행 영상 (2024.12.20, 1건)',
-    '112 신고 접수증 (2024.12.17)',
-    '사건 일지 (2024.12.15 - 2024.12.20)',
-  ];
 
   return (
     <SectionBlock title="6. 증거자료">

--- a/src/app/my-space/case/components/document/FormTable.tsx
+++ b/src/app/my-space/case/components/document/FormTable.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import { Controller } from 'react-hook-form';
-import type { FieldValues, Path, Control, UseFormRegister, UseFormWatch } from 'react-hook-form';
+import type {
+  FieldValues,
+  Path,
+  Control,
+  UseFormRegister,
+  UseFormWatch,
+  FieldErrors,
+  RegisterOptions,
+} from 'react-hook-form';
 import type { FormTableProps, CellConfig } from '@/types/document';
 import { Checkbox } from '@/components/ui/checkbox';
 
@@ -9,8 +17,16 @@ import { Checkbox } from '@/components/ui/checkbox';
  * - label 셀: 128px 고정
  * - input / checkbox-group 셀: 1fr 균등
  */
-function getGridTemplate(cells: CellConfig[]): string {
+function getGridTemplate(cells: CellConfig<FieldValues>[]): string {
   return cells.map((cell) => (cell.type === 'label' ? '128px' : '1fr')).join(' ');
+}
+
+/** 점(.)으로 연결된 path로 중첩 errors 객체에서 에러를 꺼냄 */
+function getFieldError(errors: FieldErrors, path: string) {
+  return path.split('.').reduce<unknown>((obj, key) => {
+    if (obj && typeof obj === 'object') return (obj as Record<string, unknown>)[key];
+    return undefined;
+  }, errors);
 }
 
 const cellBase = 'flex min-h-18 items-center border-r border-b border-gray-200 px-4 py-6';
@@ -20,6 +36,7 @@ export function FormTable<T extends FieldValues>({
   register,
   watch,
   control,
+  errors = {},
 }: FormTableProps<T>) {
   return (
     <div className="overflow-hidden rounded-lg border-t border-l border-gray-200">
@@ -55,6 +72,9 @@ export function FormTable<T extends FieldValues>({
               );
             }
 
+            const fieldError = getFieldError(errors as FieldErrors, cell.name);
+            const hasError = !!fieldError;
+
             return (
               <div key={i} className={cellBase}>
                 <div className="flex w-full items-center gap-1.5">
@@ -62,10 +82,16 @@ export function FormTable<T extends FieldValues>({
                     <span className="typo-heading-5 shrink-0 text-gray-500">{cell.prefix}</span>
                   )}
                   <input
-                    {...register(cell.name as Path<T>)}
+                    {...register(cell.name as Path<T>, cell.rules as RegisterOptions<T, Path<T>>)}
                     placeholder={cell.placeholder}
+                    aria-invalid={hasError}
                     className="typo-body-7 w-full bg-transparent text-gray-900 outline-none placeholder:text-gray-300"
                   />
+                  {hasError && (fieldError as { message?: string }).message && (
+                    <p className="typo-body-8 text-error shrink-0">
+                      {(fieldError as { message?: string }).message}
+                    </p>
+                  )}
                 </div>
               </div>
             );

--- a/src/app/my-space/case/components/document/RelatedCasesSection.tsx
+++ b/src/app/my-space/case/components/document/RelatedCasesSection.tsx
@@ -56,7 +56,8 @@ export function RelatedCasesSection({ control }: Props) {
               key={row.field}
               control={control}
               name={`section_7_related_cases.${row.field}`}
-              render={({ field }) => (
+              rules={{ validate: (v) => v !== null || '선택해주세요' }}
+              render={({ field, fieldState }) => (
                 <div
                   className={`grid grid-cols-[240px_1fr] ${i < ROWS.length - 1 ? 'border-b border-gray-200' : ''}`}
                 >
@@ -79,6 +80,9 @@ export function RelatedCasesSection({ control }: Props) {
                       />
                       <span className="typo-body-7 text-gray-700">{row.falseText}</span>
                     </label>
+                    {fieldState.error?.message && (
+                      <p className="typo-body-8 text-error">{fieldState.error.message}</p>
+                    )}
                   </div>
                 </div>
               )}

--- a/src/app/my-space/case/components/document/SubmissionFooter.tsx
+++ b/src/app/my-space/case/components/document/SubmissionFooter.tsx
@@ -1,4 +1,10 @@
-export function SubmissionFooter() {
+interface Props {
+  accuserName: string | null;
+  submitterName: string | null;
+  policeStation: string | null;
+}
+
+export function SubmissionFooter({ accuserName, submitterName, policeStation }: Props) {
   return (
     <div className="flex flex-col items-center gap-6">
       {/* 법적 고지 */}
@@ -22,10 +28,13 @@ export function SubmissionFooter() {
 
       {/* 고소인 · 제출인 */}
       <div className="flex flex-col gap-6">
-        {['고소인', '제출인'].map((label) => (
+        {[
+          { label: '고소인', value: accuserName },
+          { label: '제출인', value: submitterName },
+        ].map(({ label, value }) => (
           <div key={label} className="typo-body-3 flex items-end gap-2 text-black">
             <span>{label}</span>
-            <span className="w-40 border-b px-0.5" />
+            <span className="w-40 border-b px-0.5 text-center">{value ?? ''}</span>
             <span>(인)</span>
           </div>
         ))}
@@ -43,7 +52,7 @@ export function SubmissionFooter() {
       {/* 경찰서 */}
       <div className="flex items-end justify-center gap-2 pt-6">
         <div className="flex w-40 flex-col items-center">
-          <span className="typo-body-4 text-gray-300">경찰서장</span>
+          <span className="typo-body-4 text-gray-900">{policeStation ?? ''}</span>
           <span className="w-full border-b" />
         </div>
         <span className="typo-heading-1 shrink-0 text-gray-900">귀중</span>

--- a/src/app/my-space/case/components/document/TextareaSection.tsx
+++ b/src/app/my-space/case/components/document/TextareaSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import type { UseFormRegister } from 'react-hook-form';
+import type { UseFormRegister, RegisterOptions, FieldError } from 'react-hook-form';
 import type { Path } from 'react-hook-form';
 import { SectionBlock } from './SectionBlock';
 import { ContentBlock } from './ContentBlock';
@@ -14,6 +14,8 @@ interface Props {
   placeholder: string;
   fieldName: Path<DocumentFormValues>;
   register: UseFormRegister<DocumentFormValues>;
+  rules?: RegisterOptions<DocumentFormValues, Path<DocumentFormValues>>;
+  error?: FieldError;
 }
 
 export function TextareaSection({
@@ -23,9 +25,11 @@ export function TextareaSection({
   placeholder,
   fieldName,
   register,
+  rules,
+  error,
 }: Props) {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const { ref: registerRef, ...rest } = register(fieldName);
+  const { ref: registerRef, ...rest } = register(fieldName, rules);
 
   useEffect(() => {
     const el = textareaRef.current;
@@ -45,8 +49,10 @@ export function TextareaSection({
           }}
           rows={6}
           placeholder={placeholder}
+          aria-invalid={!!error}
           className="typo-body-7 focus:border-primary w-full resize-none rounded-lg border border-gray-200 bg-white px-4 py-3 text-gray-900 outline-none placeholder:text-gray-300"
         />
+        {error?.message && <p className="typo-body-8 text-error mt-1">{error.message}</p>}
       </ContentBlock>
     </SectionBlock>
   );

--- a/src/app/my-space/case/hooks/useDocument.ts
+++ b/src/app/my-space/case/hooks/useDocument.ts
@@ -1,6 +1,7 @@
 import { useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getDocument, patchDocument } from '@/api/document';
 import type { PatchDocumentPayload } from '@/types/document';
+import { showAlert } from '@/utils/alert';
 
 export function useGetDocument(complaintId: string) {
   return useSuspenseQuery({
@@ -18,6 +19,7 @@ export function usePatchDocument(complaintId: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['document', complaintId] });
       queryClient.invalidateQueries({ queryKey: ['complaint', complaintId] });
+      showAlert.success({ title: '저장되었습니다.' });
     },
   });
 }

--- a/src/app/my-space/case/hooks/useDocument.ts
+++ b/src/app/my-space/case/hooks/useDocument.ts
@@ -1,0 +1,23 @@
+import { useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getDocument, patchDocument } from '@/api/document';
+import type { PatchDocumentPayload } from '@/types/document';
+
+export function useGetDocument(complaintId: string) {
+  return useSuspenseQuery({
+    queryKey: ['document', complaintId],
+    queryFn: () => getDocument(complaintId),
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export function usePatchDocument(complaintId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: PatchDocumentPayload) => patchDocument(complaintId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['document', complaintId] });
+      queryClient.invalidateQueries({ queryKey: ['complaint', complaintId] });
+    },
+  });
+}

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import { useAuthStore } from '@/stores/authStore';
 import { useComplaint, useUpdateComplaint } from './hooks/useComplaint';
 import { needToGenerateTimeline, requestGenerateTimeline, getCurrentTaskId } from '@/api/timeline';
+import { needToGenerateDocument, requestGenerateDocument } from '@/api/document';
 import { STEP_MAP, STEP_REVERSE_MAP, type Step } from '@/types/complaint';
 import type { TimelinePhase } from '@/types/timeline';
 import {
@@ -16,7 +17,7 @@ import {
   StepComplete,
   TimelineGeneratingView,
 } from './components';
-import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { QueryErrorResetBoundary, useQueryClient } from '@tanstack/react-query';
 import { CaseErrorFallback } from '@/components/fallbacks/CaseErrorFallback';
 import { TimelineErrorFallback } from '@/components/fallbacks/TimelineErrorFallback';
 import { CasePageSkeleton } from '@/components/skeletons/CasePageSkeleton';
@@ -71,10 +72,27 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
     complaint.step === 'TIMELINE_GENERATING' ? 'restoring' : 'idle',
   );
   const [taskId, setTaskId] = useState<string | null>(null);
+  const [isDocumentGenerating, setIsDocumentGenerating] = useState(
+    complaint.step === 'DOCUMENT_GENERATING',
+  );
+  const queryClient = useQueryClient();
 
-  // 서버 데이터 → 프론트 step 변환 — 생성 플로우 진입 중에는 step 2로 표시
-  const step: Step = phase !== 'idle' ? 2 : STEP_MAP[complaint.step];
+  // 서버 데이터 → 프론트 step 변환 — 생성 플로우 진입 중에는 해당 step 유지
+  const step: Step = phase !== 'idle' ? 2 : isDocumentGenerating ? 2 : STEP_MAP[complaint.step];
   const title = complaint.name;
+
+  // DOCUMENT_GENERATING 중 polling — 3초마다 complaint 조회, DOCUMENT 확인 시 종료
+  useEffect(() => {
+    if (!isDocumentGenerating) return;
+    if (complaint.step === 'DOCUMENT') {
+      setIsDocumentGenerating(false);
+      return;
+    }
+    const id = setInterval(() => {
+      queryClient.invalidateQueries({ queryKey: ['complaint', complaintId] });
+    }, 3000);
+    return () => clearInterval(id);
+  }, [isDocumentGenerating, complaint.step, complaintId, queryClient]);
 
   // TIMELINE_GENERATING 재진입 처리 — task_id 조회 후 SSE 연결
   useEffect(() => {
@@ -122,6 +140,19 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
           return;
         }
       }
+      if (step === 2) {
+        const { need_to_generate } = await needToGenerateDocument(complaintId);
+        if (need_to_generate) {
+          await requestGenerateDocument(complaintId, 'openAI');
+          setIsDocumentGenerating(true);
+          queryClient.invalidateQueries({ queryKey: ['complaint', complaintId] });
+          return;
+        }
+        if (complaint.step === 'DOCUMENT_GENERATING') {
+          setIsDocumentGenerating(true);
+          return;
+        }
+      }
       const nextStep = clampStep(step + 1);
       save({ step: STEP_REVERSE_MAP[nextStep] });
     } catch {
@@ -160,8 +191,11 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
         isSaveDisabled={step <= 2}
         onPrev={goPrev}
         onNext={goNext}
-        hasPrev={step > MIN_STEP && (phase === 'idle' || phase === 'error')}
+        hasPrev={
+          step > MIN_STEP && (phase === 'idle' || phase === 'error') && !isDocumentGenerating
+        }
         hasNext={step < MAX_STEP && phase === 'idle'}
+        isNextLoading={isDocumentGenerating}
         updatedAt={complaint.updated_at}
       />
       <div className="space-y-6 p-6">
@@ -192,7 +226,7 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
                 ) : (
                   <StepTimeline />
                 ))}
-              {step === 3 && <StepDocument />}
+              {step === 3 && <StepDocument complaintId={complaintId} />}
               {step === 4 && <StepComplete />}
             </ErrorBoundary>
           )}

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -77,7 +77,7 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
   );
   const queryClient = useQueryClient();
   const documentPollCountRef = useRef(0);
-  const MAX_DOCUMENT_POLL = 30; // 3초 × 30 = 90초
+  const MAX_DOCUMENT_POLL = 100; // 3초 × 100 = 300초(5분)
 
   // 서버 데이터 → 프론트 step 변환 — 생성 플로우 진입 중에는 해당 step 유지
   const step: Step = phase !== 'idle' ? 2 : isDocumentGenerating ? 2 : STEP_MAP[complaint.step];

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -13,10 +13,10 @@ import {
   CaseProgress,
   StepCollect,
   StepTimeline,
-  StepDocument,
   StepComplete,
   TimelineGeneratingView,
 } from './components';
+import { StepDocument, type StepDocumentHandle } from './components/StepDocument';
 import { QueryErrorResetBoundary, useQueryClient } from '@tanstack/react-query';
 import { CaseErrorFallback } from '@/components/fallbacks/CaseErrorFallback';
 import { TimelineErrorFallback } from '@/components/fallbacks/TimelineErrorFallback';
@@ -77,6 +77,7 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
   );
   const queryClient = useQueryClient();
   const documentPollCountRef = useRef(0);
+  const stepDocumentRef = useRef<StepDocumentHandle>(null);
   const MAX_DOCUMENT_POLL = 100; // 3초 × 100 = 300초(5분)
 
   // 서버 데이터 → 프론트 step 변환 — 생성 플로우 진입 중에는 해당 step 유지
@@ -168,6 +169,13 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
           return;
         }
       }
+      if (step === 3) {
+        if (stepDocumentRef.current?.isDirty()) {
+          await stepDocumentRef.current.save();
+        }
+        stepDocumentRef.current?.submit();
+        return;
+      }
       const nextStep = clampStep(step + 1);
       save({ step: STEP_REVERSE_MAP[nextStep] });
     } catch {
@@ -192,6 +200,10 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
 
   /** 저장 버튼 클릭 */
   const handleSave = () => {
+    if (step === 3) {
+      stepDocumentRef.current?.save();
+      return;
+    }
     save({ name: title, step: STEP_REVERSE_MAP[step] });
   };
 
@@ -241,7 +253,13 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
                 ) : (
                   <StepTimeline />
                 ))}
-              {step === 3 && <StepDocument complaintId={complaintId} />}
+              {step === 3 && (
+                <StepDocument
+                  ref={stepDocumentRef}
+                  complaintId={complaintId}
+                  onValidSubmit={() => save({ step: 'COMPLETE' })}
+                />
+              )}
               {step === 4 && <StepComplete />}
             </ErrorBoundary>
           )}

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState, useEffect } from 'react';
+import { Suspense, useState, useEffect, useRef } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useAuthStore } from '@/stores/authStore';
 import { useComplaint, useUpdateComplaint } from './hooks/useComplaint';
@@ -76,19 +76,34 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
     complaint.step === 'DOCUMENT_GENERATING',
   );
   const queryClient = useQueryClient();
+  const documentPollCountRef = useRef(0);
+  const MAX_DOCUMENT_POLL = 30; // 3초 × 30 = 90초
 
   // 서버 데이터 → 프론트 step 변환 — 생성 플로우 진입 중에는 해당 step 유지
   const step: Step = phase !== 'idle' ? 2 : isDocumentGenerating ? 2 : STEP_MAP[complaint.step];
   const title = complaint.name;
 
   // DOCUMENT_GENERATING 중 polling — 3초마다 complaint 조회, DOCUMENT 확인 시 종료
+  // 90초 초과 시 생성 실패로 처리
   useEffect(() => {
-    if (!isDocumentGenerating) return;
+    if (!isDocumentGenerating) {
+      documentPollCountRef.current = 0;
+      return;
+    }
     if (complaint.step === 'DOCUMENT') {
       setIsDocumentGenerating(false);
       return;
     }
     const id = setInterval(() => {
+      if (documentPollCountRef.current >= MAX_DOCUMENT_POLL) {
+        clearInterval(id);
+        setIsDocumentGenerating(false);
+        showAlert.error({
+          title: '고소장 생성 중 오류가 발생했어요.\n다시 시도해주세요.',
+        });
+        return;
+      }
+      documentPollCountRef.current += 1;
       queryClient.invalidateQueries({ queryKey: ['complaint', complaintId] });
     }, 3000);
     return () => clearInterval(id);

--- a/src/types/complaint.ts
+++ b/src/types/complaint.ts
@@ -3,6 +3,7 @@ export type ComplaintStep =
   | 'EVIDENCE'
   | 'TIMELINE_GENERATING'
   | 'TIMELINE'
+  | 'DOCUMENT_GENERATING'
   | 'DOCUMENT'
   | 'COMPLETE';
 
@@ -25,11 +26,12 @@ export type UpdateComplaintPayload = {
   step?: ComplaintStep;
 };
 
-/** step 변환 맵 — TIMELINE_GENERATING은 프론트에서 step 2로 표시 (생성 중 UI) */
+/** step 변환 맵 — GENERATING 상태는 해당 스텝으로 표시 (생성 중 UI) */
 export const STEP_MAP: Record<ComplaintStep, Step> = {
   EVIDENCE: 1,
   TIMELINE_GENERATING: 2,
   TIMELINE: 2,
+  DOCUMENT_GENERATING: 3,
   DOCUMENT: 3,
   COMPLETE: 4,
 };

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -95,6 +95,16 @@ export type DocumentFormValues = {
   section_8_other: { content: string };
 };
 
+export type PatchDocumentPayload = Partial<DocumentFormValues>;
+
+export type NeedToGenerateDocumentResponse = {
+  need_to_generate: boolean;
+};
+
+export type RequestGenerateDocumentResponse = {
+  task_id: string;
+};
+
 export const defaultDocumentValues: DocumentFormValues = {
   section_1_complainant: {
     name_or_company: '',

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -1,4 +1,12 @@
-import type { UseFormRegister, UseFormWatch, Control, FieldValues } from 'react-hook-form';
+import type {
+  UseFormRegister,
+  UseFormWatch,
+  Control,
+  FieldValues,
+  RegisterOptions,
+  FieldErrors,
+  Path,
+} from 'react-hook-form';
 
 // ─── 셀 설정 ─────────────────────────────────────────
 
@@ -8,12 +16,14 @@ type LabelCell = {
   subText?: string;
 };
 
-type InputCell = {
+export type InputCell<T extends FieldValues = FieldValues> = {
   type?: 'input';
-  name: string;
+  name: Path<T>;
   placeholder?: string;
   /** 인라인 앞 라벨 (예: "휴대폰", "자택") */
   prefix?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rules?: RegisterOptions<any, any>;
 };
 
 type CheckboxItem = {
@@ -27,22 +37,26 @@ type CheckboxGroupCell = {
   items: CheckboxItem[];
 };
 
-export type CellConfig = LabelCell | InputCell | CheckboxGroupCell;
+export type CellConfig<T extends FieldValues = FieldValues> =
+  | LabelCell
+  | InputCell<T>
+  | CheckboxGroupCell;
 
 // ─── 행 설정 ─────────────────────────────────────────
 
-export type RowConfig = {
-  cells: [LabelCell, ...CellConfig[]];
+export type RowConfig<T extends FieldValues = FieldValues> = {
+  cells: [LabelCell, ...CellConfig<T>[]];
 };
 
 // ─── FormTable props ──────────────────────────────────
 
 export type FormTableProps<T extends FieldValues> = {
-  rows: RowConfig[];
+  rows: RowConfig<T>[];
   register: UseFormRegister<T>;
   watch: UseFormWatch<T>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   control: Control<T, any, any>;
+  errors?: FieldErrors<T>;
 };
 
 // ─── 전체 고소장 폼 값 (백엔드 스펙과 동일) ──────────────────
@@ -108,6 +122,12 @@ export type NeedToGenerateDocumentResponse = {
 
 export type RequestGenerateDocumentResponse = {
   task_id: string;
+};
+
+/** 필수 텍스트 필드 공통 규칙 */
+export const requiredText: RegisterOptions<FieldValues> = {
+  required: '필수 입력 항목입니다',
+  validate: (v: string) => !!v?.trim() || '필수 입력 항목입니다',
 };
 
 export const defaultDocumentValues: DocumentFormValues = {

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -88,11 +88,16 @@ export type DocumentFormValues = {
     evidence_list_text: string[];
   };
   section_7_related_cases: {
-    is_duplicate_complaint: boolean;
-    has_related_criminal_investigation: boolean;
-    has_related_civil_lawsuit: boolean;
+    is_duplicate_complaint: boolean | null;
+    has_related_criminal_investigation: boolean | null;
+    has_related_civil_lawsuit: boolean | null;
   };
-  section_8_other: { content: string };
+  section_8_other: { content: string | null };
+  submission_footer: {
+    accuser_name: string | null;
+    submitter_name: string | null;
+    submission_target_police_station: string | null;
+  };
 };
 
 export type PatchDocumentPayload = Partial<DocumentFormValues>;
@@ -138,9 +143,14 @@ export const defaultDocumentValues: DocumentFormValues = {
     evidence_list_text: [],
   },
   section_7_related_cases: {
-    is_duplicate_complaint: false,
-    has_related_criminal_investigation: false,
-    has_related_civil_lawsuit: false,
+    is_duplicate_complaint: null,
+    has_related_criminal_investigation: null,
+    has_related_civil_lawsuit: null,
   },
-  section_8_other: { content: '' },
+  section_8_other: { content: null },
+  submission_footer: {
+    accuser_name: null,
+    submitter_name: null,
+    submission_target_police_station: null,
+  },
 };


### PR DESCRIPTION


## 작업 내용

### 고소장 API 연동

- 고소장 문서 조회/수정 API 경로를 실제 백엔드 스펙에 맞게 수정했습니다.
  - `GET /api/v1/{complaint_id}/document/complaint-form-data`
  - `PATCH /api/v1/{complaint_id}/document/complaint-form-data`
- 고소장 문서 데이터를 조회/수정하기 위한 React Query 훅을 추가했습니다.
  - `useGetDocument`
  - `usePatchDocument`
- step2에서 step3으로 이동할 때 AI 생성 필요 여부를 확인하도록 연결했습니다.
- 문서 생성이 필요한 경우 polling으로 생성 완료 상태를 확인하도록 처리했습니다.
  - polling timeout: 기존 90초 → 300초(5분)
- 저장 성공 시 사용자에게 토스트 메시지를 표시하도록 추가했습니다.

---

### 유효성 검사

- `StepDocument` 내부 form validation을 외부 버튼에서 실행할 수 있도록 `forwardRef` + `useImperativeHandle` 패턴을 적용했습니다.
- 외부로 노출하는 메서드는 다음 세 가지입니다.
  - `submit()`: 유효성 검사 실행
  - `save()`: 현재 dirty 섹션 저장
  - `isDirty()`: 변경 여부 확인
- 유효성 검사 실패 시 첫 번째 에러 필드로 자동 스크롤되도록 처리했습니다.
  - 각 input/textarea에 `aria-invalid`를 명시적으로 부착
  - `[aria-invalid="true"]` 기준으로 첫 번째 invalid field 탐색
- 테이블형 입력 컴포넌트에서도 validation rule을 선언할 수 있도록 `FormTable` 구조를 확장했습니다.
  - `rules` 전달
  - `errors` 전달
  - 중첩 필드 에러 표시
- 필수 입력 항목에 공통 `requiredText` 규칙을 적용했습니다.
  - 단순 required뿐 아니라 공백 문자열 입력도 실패 처리

#### 섹션별 유효성 검사 기준

- `1. 고소인`
  - 성명 / 회사명
  - 주민등록번호 / 법인등록번호
  - 주소
  - 직업
  - 휴대폰 번호
  - 이메일
- `2. 피고소인`
  - 피고소인 관련 필드가 전부 비어 있는 경우 `기타사항` 필수
  - 공백 문자열도 빈 값으로 처리
- `4. 범죄사실`
  - 범죄사실 내용 필수
  - 공백 문자열만 입력한 경우 실패 처리
- `7. 관련사건`
  - 중복 고소 여부
  - 관련 형사 수사 여부
  - 관련 민사 소송 여부
  - `boolean | null` 기준으로 관리하며, `null`만 미선택으로 처리

---

### 저장 기능

- CaseHeader의 저장 버튼 클릭 시 step3 문서 폼 저장을 실행하도록 연결했습니다.
- 전체 form 데이터를 매번 전송하지 않고, 변경된 top-level 섹션만 PATCH payload에 포함하도록 처리했습니다.
- `dirtyFields` 기준으로 변경된 섹션을 판단하고, 변경사항이 없으면 PATCH 요청을 생략합니다.
- `dirtyFieldsRef`를 사용해 imperative method 내부에서 stale closure가 발생하지 않도록 처리했습니다.
- step3에서 다음 단계 클릭 시 다음 흐름으로 처리합니다.

```txt
다음 버튼 클릭
→ dirty 여부 확인
→ 변경사항이 있으면 자동 저장
→ 유효성 검사 실행
→ 통과 시 COMPLETE 저장
→ 실패 시 첫 번째 에러 필드로 스크롤
````

---

### 타입 및 컴포넌트 구조 개선

* `InputCell`, `CellConfig`, `RowConfig`를 제네릭화했습니다.
* `name: string` 대신 `Path<T>`를 사용해 필드명 오타를 타입 단계에서 방지했습니다.
* `FormTableProps<T>`에 `errors?: FieldErrors<T>`를 추가했습니다.
* 섹션 7 관련 필드 타입을 `boolean`에서 `boolean | null`로 수정했습니다.

  * 기본값도 `false`에서 `null`로 변경
  * `false` 선택값이 validation 실패로 처리되지 않도록 개선
* `TextareaSection`에 `rules`, `error` props를 추가해 재사용 가능한 validation UI로 확장했습니다.
* `RelatedCasesSection`은 `Controller`의 `fieldState.error`를 활용해 라디오 그룹 하단에 에러 메시지를 표시하도록 수정했습니다.

---

## 이슈 번호

* close #58 

---

## 스크린샷 (선택) 추가 예정

| 구분                | 화면 |
| ----------------- | -- |
| 유효성 검사 실패 시 에러 표시 |    |
| 첫 번째 에러 필드 자동 스크롤 |    |
| 저장 성공 토스트         |    |
| step3 고소장 데이터 연동  |    |

