### PR TITLE
[FEAT][#61]: 진술서 탭 구현 및 API 연동

### DIFF
--- a/src/api/document.ts
+++ b/src/api/document.ts
@@ -1,6 +1,7 @@
 import { axiosInstance } from './axiosInstance';
 import type {
   DocumentFormValues,
+  StatementFormValues,
   NeedToGenerateDocumentResponse,
   PatchDocumentPayload,
   RequestGenerateDocumentResponse,
@@ -43,6 +44,25 @@ export async function getDocument(complaintId: string) {
 export async function patchDocument(complaintId: string, payload: PatchDocumentPayload) {
   const res = await axiosInstance.patch<DocumentFormValues>(
     `/api/v1/${complaintId}/document/complaint-form-data`,
+    payload,
+  );
+  return res.data;
+}
+
+// ─── 진술서 조회 / 수정 ───────────────────────────────────
+
+/** 진술서 폼 데이터 조회 */
+export async function getStatement(complaintId: string) {
+  const res = await axiosInstance.get<StatementFormValues>(
+    `/api/v1/${complaintId}/document/statement-form-data`,
+  );
+  return res.data;
+}
+
+/** 진술서 폼 데이터 부분 수정 */
+export async function patchStatement(complaintId: string, payload: Partial<StatementFormValues>) {
+  const res = await axiosInstance.patch<StatementFormValues>(
+    `/api/v1/${complaintId}/document/statement-form-data`,
     payload,
   );
   return res.data;

--- a/src/app/my-space/case/components/StepDocument.tsx
+++ b/src/app/my-space/case/components/StepDocument.tsx
@@ -16,7 +16,12 @@ import {
   StatementContent,
 } from './document';
 import type { DocumentFormValues } from '@/types/document';
-import { useGetDocument, usePatchDocument } from '../hooks/useDocument';
+import {
+  useGetDocument,
+  usePatchDocument,
+  useGetStatement,
+  usePatchStatement,
+} from '../hooks/useDocument';
 import { useStepDocumentForm } from '../hooks/useStepDocumentForm';
 
 export type StepDocumentHandle = {
@@ -34,11 +39,15 @@ export const StepDocument = forwardRef<StepDocumentHandle, Props>(function StepD
   ref,
 ) {
   const { data: documentData } = useGetDocument(complaintId);
+  const { data: statementData } = useGetStatement(complaintId);
   const { mutateAsync: saveDocument } = usePatchDocument(complaintId);
+  const { mutateAsync: saveStatement } = usePatchStatement(complaintId);
   const rootRef = useRef<HTMLDivElement>(null);
   const { form, docForm, submit, save } = useStepDocumentForm({
     documentData,
+    statementData,
     saveDocument,
+    saveStatement,
     onValidSubmit,
     rootRef,
   });
@@ -136,7 +145,7 @@ export const StepDocument = forwardRef<StepDocumentHandle, Props>(function StepD
           <StatementContent
             register={form.register}
             errors={form.formState.errors}
-            policeStation={documentData.submission_footer.submission_target_police_station}
+            policeStation={statementData.submission_target_police_station}
           />
         </AppTabsContent>
       </AppTabs>

--- a/src/app/my-space/case/components/StepDocument.tsx
+++ b/src/app/my-space/case/components/StepDocument.tsx
@@ -3,16 +3,18 @@
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { TabsList } from '@/components/ui/tabs';
 import { AppTabs, AppTabsTrigger, AppTabsContent } from '@/components/AppTabs';
-import { ComplainantForm } from './document/ComplainantForm';
-import { DefendantForm } from './document/DefendantForm';
-import { ComplaintPurposeSection } from './document/ComplaintPurposeSection';
-import { TextareaSection } from './document/TextareaSection';
-import { EvidenceSection } from './document/EvidenceSection';
-import { RelatedCasesSection } from './document/RelatedCasesSection';
-import { SectionBlock } from './document/SectionBlock';
-import { ContentBlock } from './document/ContentBlock';
-import { SubmissionFooter } from './document/SubmissionFooter';
-import { StatementContent } from './document/StatementContent';
+import {
+  ComplainantForm,
+  DefendantForm,
+  ComplaintPurposeSection,
+  TextareaSection,
+  EvidenceSection,
+  RelatedCasesSection,
+  SectionBlock,
+  ContentBlock,
+  SubmissionFooter,
+  StatementContent,
+} from './document';
 import type { DocumentFormValues } from '@/types/document';
 import { useGetDocument, usePatchDocument } from '../hooks/useDocument';
 import { useStepDocumentForm } from '../hooks/useStepDocumentForm';

--- a/src/app/my-space/case/components/StepDocument.tsx
+++ b/src/app/my-space/case/components/StepDocument.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { forwardRef, useImperativeHandle, useCallback, useRef, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { forwardRef, useImperativeHandle } from 'react';
 import { TabsList } from '@/components/ui/tabs';
 import { AppTabs, AppTabsTrigger, AppTabsContent } from '@/components/AppTabs';
 import { ComplainantForm } from './document/ComplainantForm';
@@ -13,14 +12,14 @@ import { RelatedCasesSection } from './document/RelatedCasesSection';
 import { SectionBlock } from './document/SectionBlock';
 import { ContentBlock } from './document/ContentBlock';
 import { SubmissionFooter } from './document/SubmissionFooter';
+import { StatementContent } from './document/StatementContent';
 import type { DocumentFormValues } from '@/types/document';
-import { useGetDocument } from '../hooks/useDocument';
-import { usePatchDocument } from '../hooks/useDocument';
+import { useGetDocument, usePatchDocument } from '../hooks/useDocument';
+import { useStepDocumentForm } from '../hooks/useStepDocumentForm';
 
 export type StepDocumentHandle = {
   submit: () => void;
   save: () => Promise<void>;
-  isDirty: () => boolean;
 };
 
 interface Props {
@@ -34,51 +33,13 @@ export const StepDocument = forwardRef<StepDocumentHandle, Props>(function StepD
 ) {
   const { data: documentData } = useGetDocument(complaintId);
   const { mutateAsync: saveDocument } = usePatchDocument(complaintId);
-
-  const {
-    register,
-    watch,
-    control,
-    handleSubmit,
-    getValues,
-    formState: { errors, dirtyFields },
-  } = useForm<DocumentFormValues>({
-    defaultValues: documentData,
+  const { form, docForm, submit, save } = useStepDocumentForm({
+    documentData,
+    saveDocument,
+    onValidSubmit,
   });
 
-  const dirtyFieldsRef = useRef(dirtyFields);
-  useEffect(() => {
-    dirtyFieldsRef.current = dirtyFields;
-  });
-
-  const onInvalid = useCallback(() => {
-    window.document
-      .querySelector('[aria-invalid="true"]')
-      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  }, []);
-
-  const onValid = useCallback(
-    (values: DocumentFormValues) => {
-      onValidSubmit(values);
-    },
-    [onValidSubmit],
-  );
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      submit: () => handleSubmit(onValid, onInvalid)(),
-      isDirty: () => Object.keys(dirtyFieldsRef.current).length > 0,
-      save: async () => {
-        const values = getValues();
-        const payload = (
-          Object.keys(dirtyFieldsRef.current) as (keyof DocumentFormValues)[]
-        ).reduce((acc, key) => ({ ...acc, [key]: values[key] }), {} as Partial<DocumentFormValues>);
-        if (Object.keys(payload).length > 0) await saveDocument(payload);
-      },
-    }),
-    [handleSubmit, onValid, onInvalid, saveDocument, getValues],
-  );
+  useImperativeHandle(ref, () => ({ submit, save }), [submit, save]);
 
   return (
     <AppTabs defaultValue="complaint">
@@ -91,7 +52,7 @@ export const StepDocument = forwardRef<StepDocumentHandle, Props>(function StepD
       </div>
 
       {/* 고소장 탭 */}
-      <AppTabsContent value="complaint">
+      <AppTabsContent value="complaint" forceMount className="data-[state=inactive]:hidden">
         <div className="min-w-292 rounded-xl bg-white py-6 shadow-[0px_20px_50px_-5px_#4040400D]">
           {/* 문서 헤더 */}
           <div className="border-b border-gray-200 p-6 text-center">
@@ -103,8 +64,18 @@ export const StepDocument = forwardRef<StepDocumentHandle, Props>(function StepD
 
           {/* 폼 섹션 목록 */}
           <div className="flex flex-col gap-10 px-10 py-10">
-            <ComplainantForm register={register} watch={watch} control={control} errors={errors} />
-            <DefendantForm register={register} watch={watch} control={control} errors={errors} />
+            <ComplainantForm
+              register={docForm.register}
+              watch={docForm.watch}
+              control={docForm.control}
+              errors={docForm.errors}
+            />
+            <DefendantForm
+              register={docForm.register}
+              watch={docForm.watch}
+              control={docForm.control}
+              errors={docForm.errors}
+            />
             <ComplaintPurposeSection />
             <TextareaSection
               title="4. 범죄 사실"
@@ -112,32 +83,32 @@ export const StepDocument = forwardRef<StepDocumentHandle, Props>(function StepD
               note="※ 범죄사실은 형법 등 처벌법규에 해당하는 사실에 대하여 육하, 장소, 방법행, 결과 등을 구체적으로 특정하여 기재하여 피고소인의 얼굴과 목소리 등 외부에서 인지할 수 있는 사실만을 기재하여야 합니다"
               placeholder="범죄 사실을 입력하세요"
               fieldName="section_4_crime_facts.content"
-              register={register}
+              register={docForm.register}
               rules={{
                 required: '범죄사실 내용을 입력해주세요',
                 validate: (v: unknown) => !!(v as string)?.trim() || '범죄사실 내용을 입력해주세요',
               }}
-              error={errors.section_4_crime_facts?.content}
+              error={docForm.errors.section_4_crime_facts?.content}
             />
             <TextareaSection
               title="5. 고소 이유"
               note="※ 고소이유에는 피고소인의 범행 경위 및 경과, 고소를 하게 된 동기와 사유 등 범죄사실을 뒷받침하는 내용을 간략, 명료하게 기재하여 합니다."
               placeholder="고소 이유를 입력하세요"
               fieldName="section_5_complaint_reason.content"
-              register={register}
+              register={docForm.register}
             />
             <EvidenceSection
-              control={control}
-              watch={watch}
+              control={docForm.control}
+              watch={docForm.watch}
               evidenceList={documentData.section_6_evidence.evidence_list_text}
             />
-            <RelatedCasesSection control={control} />
+            <RelatedCasesSection control={docForm.control} />
 
             {/* 8. 기타 */}
             <SectionBlock title="8. 기타">
               <ContentBlock>
                 <textarea
-                  {...register('section_8_other.content')}
+                  {...docForm.register('section_8_other.content')}
                   rows={4}
                   placeholder="기타 추가하실 내용이 있으면 작성해주세요"
                   className="typo-body-7 focus:border-primary w-full resize-none rounded-lg border border-gray-200 bg-white px-4 py-3 text-gray-900 outline-none placeholder:text-gray-300"
@@ -154,11 +125,13 @@ export const StepDocument = forwardRef<StepDocumentHandle, Props>(function StepD
         </div>
       </AppTabsContent>
 
-      {/* 진술서 탭 (미구현) */}
-      <AppTabsContent value="statement">
-        <div className="flex items-center justify-center py-20">
-          <p className="typo-body-7 text-gray-400">진술서 준비 중입니다.</p>
-        </div>
+      {/* 진술서 탭 */}
+      <AppTabsContent value="statement" forceMount className="data-[state=inactive]:hidden">
+        <StatementContent
+          register={form.register}
+          errors={form.formState.errors}
+          policeStation={documentData.submission_footer.submission_target_police_station}
+        />
       </AppTabsContent>
     </AppTabs>
   );

--- a/src/app/my-space/case/components/StepDocument.tsx
+++ b/src/app/my-space/case/components/StepDocument.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useImperativeHandle } from 'react';
+import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { TabsList } from '@/components/ui/tabs';
 import { AppTabs, AppTabsTrigger, AppTabsContent } from '@/components/AppTabs';
 import { ComplainantForm } from './document/ComplainantForm';
@@ -33,106 +33,111 @@ export const StepDocument = forwardRef<StepDocumentHandle, Props>(function StepD
 ) {
   const { data: documentData } = useGetDocument(complaintId);
   const { mutateAsync: saveDocument } = usePatchDocument(complaintId);
+  const rootRef = useRef<HTMLDivElement>(null);
   const { form, docForm, submit, save } = useStepDocumentForm({
     documentData,
     saveDocument,
     onValidSubmit,
+    rootRef,
   });
 
-  useImperativeHandle(ref, () => ({ submit, save }), [submit, save]);
+  useImperativeHandle(ref, () => ({ submit, save }));
 
   return (
-    <AppTabs defaultValue="complaint">
-      {/* 탭 헤더 */}
-      <div className="mb-6 flex items-center justify-between">
-        <TabsList className="h-auto rounded-none bg-transparent p-0">
-          <AppTabsTrigger value="complaint">고소장</AppTabsTrigger>
-          <AppTabsTrigger value="statement">진술서</AppTabsTrigger>
-        </TabsList>
-      </div>
-
-      {/* 고소장 탭 */}
-      <AppTabsContent value="complaint" forceMount className="data-[state=inactive]:hidden">
-        <div className="min-w-292 rounded-xl bg-white py-6 shadow-[0px_20px_50px_-5px_#4040400D]">
-          {/* 문서 헤더 */}
-          <div className="border-b border-gray-200 p-6 text-center">
-            <h2 className="typo-heading-1 text-gray-900">고소장</h2>
-            <p className="typo-body-4 mt-2 text-gray-400">
-              고소장 기재사항 등 [ 필수 ] 표시된 항목은 반드시 기재하여야합니다
-            </p>
-          </div>
-
-          {/* 폼 섹션 목록 */}
-          <div className="flex flex-col gap-10 px-10 py-10">
-            <ComplainantForm
-              register={docForm.register}
-              watch={docForm.watch}
-              control={docForm.control}
-              errors={docForm.errors}
-            />
-            <DefendantForm
-              register={docForm.register}
-              watch={docForm.watch}
-              control={docForm.control}
-              errors={docForm.errors}
-            />
-            <ComplaintPurposeSection />
-            <TextareaSection
-              title="4. 범죄 사실"
-              required
-              note="※ 범죄사실은 형법 등 처벌법규에 해당하는 사실에 대하여 육하, 장소, 방법행, 결과 등을 구체적으로 특정하여 기재하여 피고소인의 얼굴과 목소리 등 외부에서 인지할 수 있는 사실만을 기재하여야 합니다"
-              placeholder="범죄 사실을 입력하세요"
-              fieldName="section_4_crime_facts.content"
-              register={docForm.register}
-              rules={{
-                required: '범죄사실 내용을 입력해주세요',
-                validate: (v: unknown) => !!(v as string)?.trim() || '범죄사실 내용을 입력해주세요',
-              }}
-              error={docForm.errors.section_4_crime_facts?.content}
-            />
-            <TextareaSection
-              title="5. 고소 이유"
-              note="※ 고소이유에는 피고소인의 범행 경위 및 경과, 고소를 하게 된 동기와 사유 등 범죄사실을 뒷받침하는 내용을 간략, 명료하게 기재하여 합니다."
-              placeholder="고소 이유를 입력하세요"
-              fieldName="section_5_complaint_reason.content"
-              register={docForm.register}
-            />
-            <EvidenceSection
-              control={docForm.control}
-              watch={docForm.watch}
-              evidenceList={documentData.section_6_evidence.evidence_list_text}
-            />
-            <RelatedCasesSection control={docForm.control} />
-
-            {/* 8. 기타 */}
-            <SectionBlock title="8. 기타">
-              <ContentBlock>
-                <textarea
-                  {...docForm.register('section_8_other.content')}
-                  rows={4}
-                  placeholder="기타 추가하실 내용이 있으면 작성해주세요"
-                  className="typo-body-7 focus:border-primary w-full resize-none rounded-lg border border-gray-200 bg-white px-4 py-3 text-gray-900 outline-none placeholder:text-gray-300"
-                />
-              </ContentBlock>
-            </SectionBlock>
-
-            <SubmissionFooter
-              accuserName={documentData.submission_footer.accuser_name}
-              submitterName={documentData.submission_footer.submitter_name}
-              policeStation={documentData.submission_footer.submission_target_police_station}
-            />
-          </div>
+    <div ref={rootRef}>
+      <AppTabs defaultValue="complaint">
+        {/* 탭 헤더 */}
+        <div className="mb-6 flex items-center justify-between">
+          <TabsList className="h-auto rounded-none bg-transparent p-0">
+            <AppTabsTrigger value="complaint">고소장</AppTabsTrigger>
+            <AppTabsTrigger value="statement">진술서</AppTabsTrigger>
+          </TabsList>
         </div>
-      </AppTabsContent>
 
-      {/* 진술서 탭 */}
-      <AppTabsContent value="statement" forceMount className="data-[state=inactive]:hidden">
-        <StatementContent
-          register={form.register}
-          errors={form.formState.errors}
-          policeStation={documentData.submission_footer.submission_target_police_station}
-        />
-      </AppTabsContent>
-    </AppTabs>
+        {/* 고소장 탭 */}
+        <AppTabsContent value="complaint" forceMount className="data-[state=inactive]:hidden">
+          <div className="min-w-292 rounded-xl bg-white py-6 shadow-[0px_20px_50px_-5px_#4040400D]">
+            {/* 문서 헤더 */}
+            <div className="border-b border-gray-200 p-6 text-center">
+              <h2 className="typo-heading-1 text-gray-900">고소장</h2>
+              <p className="typo-body-4 mt-2 text-gray-400">
+                고소장 기재사항 등 [ 필수 ] 표시된 항목은 반드시 기재하여야합니다
+              </p>
+            </div>
+
+            {/* 폼 섹션 목록 */}
+            <div className="flex flex-col gap-10 px-10 py-10">
+              <ComplainantForm
+                register={docForm.register}
+                watch={docForm.watch}
+                control={docForm.control}
+                errors={docForm.errors}
+              />
+              <DefendantForm
+                register={docForm.register}
+                watch={docForm.watch}
+                control={docForm.control}
+                errors={docForm.errors}
+              />
+              <ComplaintPurposeSection />
+              <TextareaSection
+                title="4. 범죄 사실"
+                required
+                note="※ 범죄사실은 형법 등 처벌법규에 해당하는 사실에 대하여 육하, 장소, 방법행, 결과 등을 구체적으로 특정하여 기재하여 피고소인의 얼굴과 목소리 등 외부에서 인지할 수 있는 사실만을 기재하여야 합니다"
+                placeholder="범죄 사실을 입력하세요"
+                fieldName="section_4_crime_facts.content"
+                register={docForm.register}
+                rules={{
+                  required: '범죄사실 내용을 입력해주세요',
+                  validate: (v: unknown) =>
+                    !!(v as string)?.trim() || '범죄사실 내용을 입력해주세요',
+                }}
+                error={docForm.errors.section_4_crime_facts?.content}
+              />
+              <TextareaSection
+                title="5. 고소 이유"
+                note="※ 고소이유에는 피고소인의 범행 경위 및 경과, 고소를 하게 된 동기와 사유 등 범죄사실을 뒷받침하는 내용을 간략, 명료하게 기재하여 합니다."
+                placeholder="고소 이유를 입력하세요"
+                fieldName="section_5_complaint_reason.content"
+                register={docForm.register}
+              />
+              <EvidenceSection
+                control={docForm.control}
+                watch={docForm.watch}
+                evidenceList={documentData.section_6_evidence.evidence_list_text}
+              />
+              <RelatedCasesSection control={docForm.control} />
+
+              {/* 8. 기타 */}
+              <SectionBlock title="8. 기타">
+                <ContentBlock>
+                  <textarea
+                    {...docForm.register('section_8_other.content')}
+                    rows={4}
+                    placeholder="기타 추가하실 내용이 있으면 작성해주세요"
+                    className="typo-body-7 focus:border-primary w-full resize-none rounded-lg border border-gray-200 bg-white px-4 py-3 text-gray-900 outline-none placeholder:text-gray-300"
+                  />
+                </ContentBlock>
+              </SectionBlock>
+
+              <SubmissionFooter
+                accuserName={documentData.submission_footer.accuser_name}
+                submitterName={documentData.submission_footer.submitter_name}
+                policeStation={documentData.submission_footer.submission_target_police_station}
+              />
+            </div>
+          </div>
+        </AppTabsContent>
+
+        {/* 진술서 탭 */}
+        <AppTabsContent value="statement" forceMount className="data-[state=inactive]:hidden">
+          <StatementContent
+            register={form.register}
+            errors={form.formState.errors}
+            policeStation={documentData.submission_footer.submission_target_police_station}
+          />
+        </AppTabsContent>
+      </AppTabs>
+    </div>
   );
 });

--- a/src/app/my-space/case/components/document/StatementContent.tsx
+++ b/src/app/my-space/case/components/document/StatementContent.tsx
@@ -1,10 +1,11 @@
+import { useEffect, useRef } from 'react';
 import type { UseFormRegister, FieldErrors } from 'react-hook-form';
 import type { CombinedDocumentFormValues } from '@/types/document';
 
 const GUIDE_ITEMS = [
-  '불이익을 받지 않으려면 진실을 말하고 진술을 잘 해주시기 바랍니다.',
-  '진술사항은 사건에 관하여 알고 있는 모든 내용을 빠짐없이 진술하여 주십시오.',
-  '각 칸은 끝까지 작성하셔야 하고, 법회검토 기재 후 다음 페이지로 넘어갑니다.',
+  '진술서는 피해 사실을 본인의 언어로 자유롭게 작성하는 문서입니다.',
+  '시간 순서대로 구체적인 사실을 기재하되, 감정이나 느낌도 함께 서술하시면 좋습니다.',
+  '피해로 인한 정신적·신체적 고통, 일상생활의 어려움 등도 상세히 기록해주세요.',
 ];
 
 interface Props {
@@ -14,21 +15,34 @@ interface Props {
 }
 
 export function StatementContent({ register, errors, policeStation }: Props) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const { ref: registerRef, ...statementRest } = register('statement.damage_facts_statement', {
+    required: '피해 사실 진술을 입력해주세요',
+    validate: (v: string) => !!v?.trim() || '피해 사실 진술을 입력해주세요',
+  });
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  });
+
   return (
     <div className="min-w-292 rounded-xl bg-white py-6 shadow-[0px_20px_50px_-5px_#4040400D]">
       {/* 문서 헤더 */}
-      <div className="border-b border-gray-200 p-6 text-center">
+      <div className="border-b border-gray-200 px-6 py-12 text-center">
         <h2 className="typo-heading-1 text-gray-900">진술서</h2>
-        <p className="typo-body-4 mt-2 text-gray-400">스토킹 피해 사실의 진정 진술서</p>
+        <p className="typo-body-4 mt-2 text-gray-400">스토킹 피해 사실에 관한 진술서</p>
       </div>
 
-      <div className="flex flex-col gap-10 px-10 py-10">
+      <div className="flex flex-col gap-6 px-6 py-12">
         {/* 작성 안내 */}
-        <div className="rounded-lg bg-gray-50 px-5 py-4">
-          <p className="typo-label mb-2 text-gray-700">진술서 작성 안내</p>
-          <ul className="flex flex-col gap-1">
+        <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+          <p className="typo-heading-5 mb-2">진술서 작성 안내</p>
+          <ul className="flex flex-col gap-2">
             {GUIDE_ITEMS.map((item) => (
-              <li key={item} className="typo-body-7 flex gap-1.5 text-gray-500">
+              <li key={item} className="typo-body-6 flex gap-1.5 text-gray-500">
                 <span className="shrink-0">•</span>
                 <span>{item}</span>
               </li>
@@ -38,18 +52,19 @@ export function StatementContent({ register, errors, policeStation }: Props) {
 
         {/* 피해 사실 진술 */}
         <div className="flex flex-col gap-2">
-          <p className="typo-label text-gray-900">
-            피해 사실 진술 <span className="text-error">*</span>
-          </p>
+          <h3 className="typo-body-2 text-gray-700">
+            피해 사실 진술<span className="typo-label text-primary ml-1">필수</span>
+          </h3>
           <textarea
-            {...register('statement.damage_facts_statement', {
-              required: '피해 사실 진술을 입력해주세요',
-              validate: (v: string) => !!v?.trim() || '피해 사실 진술을 입력해주세요',
-            })}
-            rows={8}
+            {...statementRest}
+            ref={(el) => {
+              registerRef(el);
+              textareaRef.current = el;
+            }}
+            style={{ minHeight: '336px' }}
             placeholder="피해 사실을 입력해주세요"
             aria-invalid={!!errors?.statement?.damage_facts_statement}
-            className="typo-body-7 w-full resize-none text-gray-900 outline-none placeholder:text-gray-300"
+            className="typo-body-7 focus:border-primary w-full resize-none rounded-lg border border-gray-200 bg-white px-4 py-3 text-gray-900 outline-none placeholder:text-gray-300"
           />
           {errors?.statement?.damage_facts_statement && (
             <p className="typo-body-8 text-error">
@@ -60,7 +75,9 @@ export function StatementContent({ register, errors, policeStation }: Props) {
 
         {/* 하단 서명 영역 */}
         <div className="flex flex-col items-center gap-6 pt-4">
-          <p className="typo-body-7 text-center text-black">이 진술은 사실과 다름이 없습니다</p>
+          <p className="typo-body-7 text-center text-black">
+            위 진술 내용은 사실과 다름없음을 확인합니다
+          </p>
 
           {/* 날짜 */}
           <div className="typo-body-3 flex items-end justify-center gap-2 text-black">

--- a/src/app/my-space/case/components/document/StatementContent.tsx
+++ b/src/app/my-space/case/components/document/StatementContent.tsx
@@ -1,0 +1,109 @@
+import type { UseFormRegister, FieldErrors } from 'react-hook-form';
+import type { CombinedDocumentFormValues } from '@/types/document';
+
+const GUIDE_ITEMS = [
+  '불이익을 받지 않으려면 진실을 말하고 진술을 잘 해주시기 바랍니다.',
+  '진술사항은 사건에 관하여 알고 있는 모든 내용을 빠짐없이 진술하여 주십시오.',
+  '각 칸은 끝까지 작성하셔야 하고, 법회검토 기재 후 다음 페이지로 넘어갑니다.',
+];
+
+interface Props {
+  register: UseFormRegister<CombinedDocumentFormValues>;
+  errors?: FieldErrors<CombinedDocumentFormValues>;
+  policeStation?: string | null;
+}
+
+export function StatementContent({ register, errors, policeStation }: Props) {
+  return (
+    <div className="min-w-292 rounded-xl bg-white py-6 shadow-[0px_20px_50px_-5px_#4040400D]">
+      {/* 문서 헤더 */}
+      <div className="border-b border-gray-200 p-6 text-center">
+        <h2 className="typo-heading-1 text-gray-900">진술서</h2>
+        <p className="typo-body-4 mt-2 text-gray-400">스토킹 피해 사실의 진정 진술서</p>
+      </div>
+
+      <div className="flex flex-col gap-10 px-10 py-10">
+        {/* 작성 안내 */}
+        <div className="rounded-lg bg-gray-50 px-5 py-4">
+          <p className="typo-label mb-2 text-gray-700">진술서 작성 안내</p>
+          <ul className="flex flex-col gap-1">
+            {GUIDE_ITEMS.map((item) => (
+              <li key={item} className="typo-body-7 flex gap-1.5 text-gray-500">
+                <span className="shrink-0">•</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* 피해 사실 진술 */}
+        <div className="flex flex-col gap-2">
+          <p className="typo-label text-gray-900">
+            피해 사실 진술 <span className="text-error">*</span>
+          </p>
+          <textarea
+            {...register('statement.damage_facts_statement', {
+              required: '피해 사실 진술을 입력해주세요',
+              validate: (v: string) => !!v?.trim() || '피해 사실 진술을 입력해주세요',
+            })}
+            rows={8}
+            placeholder="피해 사실을 입력해주세요"
+            aria-invalid={!!errors?.statement?.damage_facts_statement}
+            className="typo-body-7 w-full resize-none text-gray-900 outline-none placeholder:text-gray-300"
+          />
+          {errors?.statement?.damage_facts_statement && (
+            <p className="typo-body-8 text-error">
+              {errors.statement.damage_facts_statement.message}
+            </p>
+          )}
+        </div>
+
+        {/* 하단 서명 영역 */}
+        <div className="flex flex-col items-center gap-6 pt-4">
+          <p className="typo-body-7 text-center text-black">이 진술은 사실과 다름이 없습니다</p>
+
+          {/* 날짜 */}
+          <div className="typo-body-3 flex items-end justify-center gap-2 text-black">
+            <span>20</span>
+            <span className="w-16 border-b px-0.5" />
+            <span>년</span>
+            <span className="w-16 border-b px-0.5" />
+            <span>월</span>
+            <span className="w-16 border-b px-0.5" />
+            <span>일</span>
+          </div>
+
+          {/* 진술인 */}
+          <div className="flex flex-col items-center gap-1">
+            <div className="typo-body-3 flex items-end gap-2 text-black">
+              <span>진술인</span>
+              <input
+                {...register('statement.declarant_name', {
+                  required: '진술인 이름을 입력해주세요',
+                })}
+                className="w-40 border-b bg-transparent px-0.5 text-center outline-none focus:border-gray-500"
+              />
+              <span>(인)</span>
+            </div>
+            {errors?.statement?.declarant_name && (
+              <p className="typo-body-8 text-red-500">{errors.statement.declarant_name.message}</p>
+            )}
+          </div>
+
+          {/* 경찰청 귀중 */}
+          <div className="flex items-end justify-center gap-2 pt-6">
+            <div className="flex w-40 flex-col items-center">
+              <span className="typo-body-4 text-gray-900">{policeStation ?? ''}</span>
+              <span className="w-full border-b" />
+            </div>
+            <span className="typo-heading-1 shrink-0 text-gray-900">귀중</span>
+          </div>
+
+          <p className="typo-body-8 -mt-4 text-center text-gray-300">
+            ※ 고소장 기재 시 가까운 경찰서에 제출해주세요
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/my-space/case/components/document/index.ts
+++ b/src/app/my-space/case/components/document/index.ts
@@ -1,0 +1,10 @@
+export { ComplainantForm } from './ComplainantForm';
+export { DefendantForm } from './DefendantForm';
+export { ComplaintPurposeSection } from './ComplaintPurposeSection';
+export { TextareaSection } from './TextareaSection';
+export { EvidenceSection } from './EvidenceSection';
+export { RelatedCasesSection } from './RelatedCasesSection';
+export { SectionBlock } from './SectionBlock';
+export { ContentBlock } from './ContentBlock';
+export { SubmissionFooter } from './SubmissionFooter';
+export { StatementContent } from './StatementContent';

--- a/src/app/my-space/case/hooks/useDocument.ts
+++ b/src/app/my-space/case/hooks/useDocument.ts
@@ -1,7 +1,6 @@
 import { useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getDocument, patchDocument } from '@/api/document';
-import type { PatchDocumentPayload } from '@/types/document';
-import { showAlert } from '@/utils/alert';
+import { getDocument, patchDocument, getStatement, patchStatement } from '@/api/document';
+import type { PatchDocumentPayload, StatementFormValues } from '@/types/document';
 
 export function useGetDocument(complaintId: string) {
   return useSuspenseQuery({
@@ -19,7 +18,25 @@ export function usePatchDocument(complaintId: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['document', complaintId] });
       queryClient.invalidateQueries({ queryKey: ['complaint', complaintId] });
-      showAlert.success({ title: '저장되었습니다.' });
+    },
+  });
+}
+
+export function useGetStatement(complaintId: string) {
+  return useSuspenseQuery({
+    queryKey: ['statement', complaintId],
+    queryFn: () => getStatement(complaintId),
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export function usePatchStatement(complaintId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: Partial<StatementFormValues>) => patchStatement(complaintId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['statement', complaintId] });
     },
   });
 }

--- a/src/app/my-space/case/hooks/useStepDocumentForm.ts
+++ b/src/app/my-space/case/hooks/useStepDocumentForm.ts
@@ -1,13 +1,14 @@
 'use client';
 
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, type RefObject } from 'react';
 import { useForm } from 'react-hook-form';
 import type { UseFormRegister, UseFormWatch, Control, FieldErrors } from 'react-hook-form';
 import type { DocumentFormValues, CombinedDocumentFormValues } from '@/types/document';
 import { showAlert } from '@/utils/alert';
 
 const getDocumentValues = (values: CombinedDocumentFormValues): DocumentFormValues => {
-  const { statement: _statement, ...documentValues } = values;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { statement, ...documentValues } = values;
   return documentValues;
 };
 
@@ -15,6 +16,7 @@ interface Params {
   documentData: DocumentFormValues;
   saveDocument: (payload: Partial<DocumentFormValues>) => Promise<unknown>;
   onValidSubmit: (values: DocumentFormValues) => void;
+  rootRef: RefObject<HTMLElement | null>;
 }
 
 interface DocForm {
@@ -24,7 +26,12 @@ interface DocForm {
   errors: FieldErrors<DocumentFormValues>;
 }
 
-export function useStepDocumentForm({ documentData, saveDocument, onValidSubmit }: Params) {
+export function useStepDocumentForm({
+  documentData,
+  saveDocument,
+  onValidSubmit,
+  rootRef,
+}: Params) {
   const form = useForm<CombinedDocumentFormValues>({
     defaultValues: {
       ...documentData,
@@ -61,7 +68,8 @@ export function useStepDocumentForm({ documentData, saveDocument, onValidSubmit 
     values: CombinedDocumentFormValues,
   ): Partial<DocumentFormValues> => {
     const documentValues = getDocumentValues(values);
-    const { statement: _statement, ...documentDirtyFields } = dirtyFieldsRef.current;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { statement, ...documentDirtyFields } = dirtyFieldsRef.current;
     return Object.keys(documentDirtyFields).reduce((acc, key) => {
       const documentKey = key as keyof DocumentFormValues;
       return { ...acc, [documentKey]: documentValues[documentKey] };
@@ -69,9 +77,9 @@ export function useStepDocumentForm({ documentData, saveDocument, onValidSubmit 
   };
 
   const scrollToFirstInvalid = () => {
-    const invalidEl = Array.from(window.document.querySelectorAll('[aria-invalid="true"]')).find(
-      (el) => (el as HTMLElement).offsetParent !== null,
-    );
+    const invalidEl = Array.from(
+      rootRef.current?.querySelectorAll('[aria-invalid="true"]') ?? [],
+    ).find((el) => (el as HTMLElement).offsetParent !== null);
     invalidEl?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   };
 
@@ -82,18 +90,15 @@ export function useStepDocumentForm({ documentData, saveDocument, onValidSubmit 
     scrollToFirstInvalid();
   };
 
-  const submit = useCallback(
-    () =>
-      handleSubmit(async (values) => {
-        const documentValues = getDocumentValues(values);
-        const payload = getDirtyDocumentPayload(values);
-        if (Object.keys(payload).length > 0) await saveDocument(payload);
-        onValidSubmit(documentValues);
-      }, handleInvalidSubmit)(),
-    [handleSubmit, saveDocument, onValidSubmit],
-  );
+  const submit = () =>
+    handleSubmit(async (values) => {
+      const documentValues = getDocumentValues(values);
+      const payload = getDirtyDocumentPayload(values);
+      if (Object.keys(payload).length > 0) await saveDocument(payload);
+      onValidSubmit(documentValues);
+    }, handleInvalidSubmit)();
 
-  const save = useCallback(async () => {
+  const save = async () => {
     const isValid = await trigger();
     if (!isValid) {
       handleInvalidSubmit();
@@ -102,7 +107,7 @@ export function useStepDocumentForm({ documentData, saveDocument, onValidSubmit 
     const values = getValues();
     const payload = getDirtyDocumentPayload(values);
     if (Object.keys(payload).length > 0) await saveDocument(payload);
-  }, [trigger, getValues, saveDocument]);
+  };
 
   return { form, docForm, submit, save };
 }

--- a/src/app/my-space/case/hooks/useStepDocumentForm.ts
+++ b/src/app/my-space/case/hooks/useStepDocumentForm.ts
@@ -1,0 +1,108 @@
+'use client';
+
+import { useRef, useEffect, useCallback } from 'react';
+import { useForm } from 'react-hook-form';
+import type { UseFormRegister, UseFormWatch, Control, FieldErrors } from 'react-hook-form';
+import type { DocumentFormValues, CombinedDocumentFormValues } from '@/types/document';
+import { showAlert } from '@/utils/alert';
+
+const getDocumentValues = (values: CombinedDocumentFormValues): DocumentFormValues => {
+  const { statement: _statement, ...documentValues } = values;
+  return documentValues;
+};
+
+interface Params {
+  documentData: DocumentFormValues;
+  saveDocument: (payload: Partial<DocumentFormValues>) => Promise<unknown>;
+  onValidSubmit: (values: DocumentFormValues) => void;
+}
+
+interface DocForm {
+  register: UseFormRegister<DocumentFormValues>;
+  watch: UseFormWatch<DocumentFormValues>;
+  control: Control<DocumentFormValues>;
+  errors: FieldErrors<DocumentFormValues>;
+}
+
+export function useStepDocumentForm({ documentData, saveDocument, onValidSubmit }: Params) {
+  const form = useForm<CombinedDocumentFormValues>({
+    defaultValues: {
+      ...documentData,
+      statement: {
+        damage_facts_statement: '',
+        declarant_name: '',
+        submission_target_police_station: '',
+      },
+    },
+  });
+  const {
+    register,
+    watch,
+    control,
+    handleSubmit,
+    getValues,
+    trigger,
+    formState: { errors, dirtyFields },
+  } = form;
+
+  const dirtyFieldsRef = useRef(dirtyFields);
+  useEffect(() => {
+    dirtyFieldsRef.current = dirtyFields;
+  });
+
+  const docForm: DocForm = {
+    register: register as unknown as UseFormRegister<DocumentFormValues>,
+    watch: watch as unknown as UseFormWatch<DocumentFormValues>,
+    control: control as unknown as Control<DocumentFormValues>,
+    errors: errors as unknown as FieldErrors<DocumentFormValues>,
+  };
+
+  const getDirtyDocumentPayload = (
+    values: CombinedDocumentFormValues,
+  ): Partial<DocumentFormValues> => {
+    const documentValues = getDocumentValues(values);
+    const { statement: _statement, ...documentDirtyFields } = dirtyFieldsRef.current;
+    return Object.keys(documentDirtyFields).reduce((acc, key) => {
+      const documentKey = key as keyof DocumentFormValues;
+      return { ...acc, [documentKey]: documentValues[documentKey] };
+    }, {} as Partial<DocumentFormValues>);
+  };
+
+  const scrollToFirstInvalid = () => {
+    const invalidEl = Array.from(window.document.querySelectorAll('[aria-invalid="true"]')).find(
+      (el) => (el as HTMLElement).offsetParent !== null,
+    );
+    invalidEl?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  const handleInvalidSubmit = () => {
+    showAlert.error({
+      title: '고소장·진술서의 필수 항목을 확인해주세요.',
+    });
+    scrollToFirstInvalid();
+  };
+
+  const submit = useCallback(
+    () =>
+      handleSubmit(async (values) => {
+        const documentValues = getDocumentValues(values);
+        const payload = getDirtyDocumentPayload(values);
+        if (Object.keys(payload).length > 0) await saveDocument(payload);
+        onValidSubmit(documentValues);
+      }, handleInvalidSubmit)(),
+    [handleSubmit, saveDocument, onValidSubmit],
+  );
+
+  const save = useCallback(async () => {
+    const isValid = await trigger();
+    if (!isValid) {
+      handleInvalidSubmit();
+      return;
+    }
+    const values = getValues();
+    const payload = getDirtyDocumentPayload(values);
+    if (Object.keys(payload).length > 0) await saveDocument(payload);
+  }, [trigger, getValues, saveDocument]);
+
+  return { form, docForm, submit, save };
+}

--- a/src/app/my-space/case/hooks/useStepDocumentForm.ts
+++ b/src/app/my-space/case/hooks/useStepDocumentForm.ts
@@ -3,7 +3,11 @@
 import { useRef, useEffect, type RefObject } from 'react';
 import { useForm } from 'react-hook-form';
 import type { UseFormRegister, UseFormWatch, Control, FieldErrors } from 'react-hook-form';
-import type { DocumentFormValues, CombinedDocumentFormValues } from '@/types/document';
+import type {
+  DocumentFormValues,
+  StatementFormValues,
+  CombinedDocumentFormValues,
+} from '@/types/document';
 import { showAlert } from '@/utils/alert';
 
 const getDocumentValues = (values: CombinedDocumentFormValues): DocumentFormValues => {
@@ -14,7 +18,9 @@ const getDocumentValues = (values: CombinedDocumentFormValues): DocumentFormValu
 
 interface Params {
   documentData: DocumentFormValues;
+  statementData: StatementFormValues;
   saveDocument: (payload: Partial<DocumentFormValues>) => Promise<unknown>;
+  saveStatement: (payload: Partial<StatementFormValues>) => Promise<unknown>;
   onValidSubmit: (values: DocumentFormValues) => void;
   rootRef: RefObject<HTMLElement | null>;
 }
@@ -28,18 +34,16 @@ interface DocForm {
 
 export function useStepDocumentForm({
   documentData,
+  statementData,
   saveDocument,
+  saveStatement,
   onValidSubmit,
   rootRef,
 }: Params) {
   const form = useForm<CombinedDocumentFormValues>({
     defaultValues: {
       ...documentData,
-      statement: {
-        damage_facts_statement: '',
-        declarant_name: '',
-        submission_target_police_station: '',
-      },
+      statement: statementData,
     },
   });
   const {
@@ -76,6 +80,29 @@ export function useStepDocumentForm({
     }, {} as Partial<DocumentFormValues>);
   };
 
+  const getDirtyStatementPayload = (
+    values: CombinedDocumentFormValues,
+  ): Partial<StatementFormValues> => {
+    const statementDirtyFields = dirtyFieldsRef.current.statement;
+    if (!statementDirtyFields) return {};
+    return Object.keys(statementDirtyFields).reduce((acc, key) => {
+      const statementKey = key as keyof StatementFormValues;
+      return { ...acc, [statementKey]: values.statement[statementKey] };
+    }, {} as Partial<StatementFormValues>);
+  };
+
+  const saveDirtyFields = async (values: CombinedDocumentFormValues, showToast = true) => {
+    const documentPayload = getDirtyDocumentPayload(values);
+    const statementPayload = getDirtyStatementPayload(values);
+    const hasChanges =
+      Object.keys(documentPayload).length > 0 || Object.keys(statementPayload).length > 0;
+    await Promise.all([
+      Object.keys(documentPayload).length > 0 ? saveDocument(documentPayload) : null,
+      Object.keys(statementPayload).length > 0 ? saveStatement(statementPayload) : null,
+    ]);
+    if (showToast && hasChanges) showAlert.success({ title: '저장되었습니다.' });
+  };
+
   const scrollToFirstInvalid = () => {
     const invalidEl = Array.from(
       rootRef.current?.querySelectorAll('[aria-invalid="true"]') ?? [],
@@ -92,10 +119,8 @@ export function useStepDocumentForm({
 
   const submit = () =>
     handleSubmit(async (values) => {
-      const documentValues = getDocumentValues(values);
-      const payload = getDirtyDocumentPayload(values);
-      if (Object.keys(payload).length > 0) await saveDocument(payload);
-      onValidSubmit(documentValues);
+      await saveDirtyFields(values, false);
+      onValidSubmit(getDocumentValues(values));
     }, handleInvalidSubmit)();
 
   const save = async () => {
@@ -104,9 +129,7 @@ export function useStepDocumentForm({
       handleInvalidSubmit();
       return;
     }
-    const values = getValues();
-    const payload = getDirtyDocumentPayload(values);
-    if (Object.keys(payload).length > 0) await saveDocument(payload);
+    await saveDirtyFields(getValues());
   };
 
   return { form, docForm, submit, save };

--- a/src/app/my-space/case/page.tsx
+++ b/src/app/my-space/case/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState, useEffect, useRef } from 'react';
+import { Suspense, useState, useEffect, useRef, useCallback } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useAuthStore } from '@/stores/authStore';
 import { useComplaint, useUpdateComplaint } from './hooks/useComplaint';
@@ -170,9 +170,6 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
         }
       }
       if (step === 3) {
-        if (stepDocumentRef.current?.isDirty()) {
-          await stepDocumentRef.current.save();
-        }
         stepDocumentRef.current?.submit();
         return;
       }
@@ -192,6 +189,8 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
     const prevStep = clampStep(step - 1);
     save({ step: STEP_REVERSE_MAP[prevStep] });
   };
+
+  const handleValidSubmit = useCallback(() => save({ step: 'COMPLETE' }), [save]);
 
   /** 제목 변경 + 서버 저장 */
   const handleTitleChange = (newTitle: string) => {
@@ -257,7 +256,7 @@ function CasePageContent({ complaintId }: { complaintId: string }) {
                 <StepDocument
                   ref={stepDocumentRef}
                   complaintId={complaintId}
-                  onValidSubmit={() => save({ step: 'COMPLETE' })}
+                  onValidSubmit={handleValidSubmit}
                 />
               )}
               {step === 4 && <StepComplete />}

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -114,6 +114,16 @@ export type DocumentFormValues = {
   };
 };
 
+export type StatementFormValues = {
+  damage_facts_statement: string;
+  declarant_name: string;
+  submission_target_police_station: string;
+};
+
+export type CombinedDocumentFormValues = DocumentFormValues & {
+  statement: StatementFormValues;
+};
+
 export type PatchDocumentPayload = Partial<DocumentFormValues>;
 
 export type NeedToGenerateDocumentResponse = {


### PR DESCRIPTION

## 작업 내용

### 진술서 탭 UI 구현
"진술서 준비 중" placeholder 상태였던 진술서 탭을 실제 UI로 구현했습니다. `StatementContent` 컴포넌트를 신규 추가했습니다.
- 진술서 작성 안내 문구
- 피해 사실 진술 textarea (필수, 공백 validate, auto-resize, minHeight 336px)
- 진술인 이름 input (필수)
- 날짜 서명란
- 경찰서명 표시

### 진술서 API 연동
기존에는 진술서 필드가 빈 문자열로 초기화되고 저장 시 PATCH에도 포함되지 않았습니다.
- `getStatement` / `patchStatement` API 함수 추가 (`GET·PATCH /api/v1/{complaint_id}/document/statement-form-data`)
- `useGetStatement` / `usePatchStatement` React Query 훅 추가
- 폼 초기값을 API 조회 값으로 연동
- `policeStation` 표시값을 진술서 API에서 가져오도록 변경

### 고소장·진술서 통합 폼 관리
탭 전환 시 비활성 탭이 언마운트되면서 RHF 등록이 해제되어 유효성 검사가 적용되지 않는 문제를 해결했습니다.
- `forceMount` + `data-[state=inactive]:hidden` — 비활성 탭도 DOM에 유지하되 CSS로 숨김. 두 탭의 필드가 항상 마운트 상태이므로 RHF 등록이 유지됩니다.
- `CombinedDocumentFormValues` 타입을 추가해 `useForm` 인스턴스 하나로 고소장·진술서를 통합 관리합니다. 고소장 자식 컴포넌트에는 `register as UseFormRegister<DocumentFormValues>`로 캐스팅해 전달하고, 진술서 탭에는 `form.register`를 그대로 전달합니다.
- 유효성 검사 실패 시 어느 탭에 있든 toast 알림을 띄우고 첫 번째 invalid 필드로 자동 스크롤합니다. 비활성 탭의 hidden 필드는 `offsetParent !== null` 체크로 걸러냅니다.

### 폼 로직 훅 분리 — `useStepDocumentForm`
`StepDocument` 컴포넌트에 인라인으로 있던 폼 로직 전체를 커스텀 훅으로 분리했습니다.
- `dirtyFieldsRef` 패턴 — `useRef` + `useEffect`(no deps)로 클로저 stale 없이 항상 최신 dirty 상태 참조
- `getDirtyDocumentPayload` — dirty 고소장 필드만 추출
- `getDirtyStatementPayload` — dirty 진술서 필드만 추출
- `saveDirtyFields` — 고소장·진술서 PATCH를 `Promise.all`로 동시 처리. `showToast` 옵션으로 toast 제어 (저장 버튼에서만 표시, 다음 버튼은 바로 이동하므로 생략)
- `scrollToFirstInvalid` — `rootRef.current` 기준으로 `[aria-invalid="true"]` 탐색 (전역 `window.document` 탐색에서 StepDocument 영역으로 제한)

### 유효성 검사 버그 수정
- 기존 `save()` 문제: 유효성 검사 없이 dirty 필드를 바로 PATCH하고 있었습니다. `trigger()`를 먼저 실행해 유효성 통과 후에만 PATCH 요청을 보내도록 수정했습니다.
- 기존 `goNext` step 3 문제: `save()`를 먼저 호출한 뒤 `submit()`을 호출하는 이중 호출 구조였습니다. `submit()` 단독 호출로 수정했습니다. `submit()` 내부에서 유효성 통과 후 dirty 필드 PATCH → `onValidSubmit` 실행까지 처리합니다.

### 기타
- `StepDocumentHandle`에서 실제 사용처 없는 `isDirty()` 제거
- `page.tsx` `onValidSubmit` inline arrow를 `handleValidSubmit = useCallback()`으로 분리 — 매 렌더마다 새 함수 참조가 생성되어 불필요한 재생성이 유발되는 문제 방지
- `document/index.ts` 추가 — `StepDocument`의 개별 파일 import 10개를 단일 block으로 정리

### 동작 흐름
- 저장 버튼 클릭 (save())
```
저장 버튼
→ page.tsx handleSave()
→ stepDocumentRef.current.save()
→ trigger() — 고소장·진술서 전 필드 유효성 검사

  [실패]
  → handleInvalidSubmit()
    → toast("고소장·진술서의 필수 항목을 확인해주세요.")
    → 첫 번째 invalid 필드로 스크롤
    → 종료 (PATCH 없음)

  [성공]
  → saveDirtyFields(getValues(), showToast=true)
    → getDirtyDocumentPayload() — dirty 고소장 필드 추출
    → getDirtyStatementPayload() — dirty 진술서 필드 추출
    → Promise.all([patchDocument, patchStatement]) — 변경된 것만 전송
    → 변경사항 있으면 toast("저장되었습니다.")
```    

- 다음 버튼 클릭 (submit())
```
다음 버튼
→ page.tsx goNext() (step === 3)
→ stepDocumentRef.current.submit()
→ handleSubmit(onValid, handleInvalidSubmit)()

  [실패]
  → handleInvalidSubmit()
    → toast("고소장·진술서의 필수 항목을 확인해주세요.")
    → 첫 번째 invalid 필드로 스크롤
    → 종료 (PATCH 없음, 단계 이동 없음)

  [성공]
  → saveDirtyFields(values, showToast=false) — toast 없이 저장
    → Promise.all([patchDocument, patchStatement])
  → onValidSubmit(documentValues)
    → page.tsx handleValidSubmit()
    → save({ step: 'COMPLETE' }) — complaint step 서버 저장
    → step 4로 이동
```

## 이슈 번호
close #61 

## 스크린샷 (선택)

<img width="1837" height="1413" alt="image" src="https://github.com/user-attachments/assets/33f3dfc4-3e39-488c-ad28-19b78dbc05a1" />
