### PR TITLE
[FEAT][#63]: 사이드바 유저 메뉴 추가 및 로그아웃 분기 처리

### DIFF
--- a/src/app/auth/hooks/useLoginForm.ts
+++ b/src/app/auth/hooks/useLoginForm.ts
@@ -33,7 +33,7 @@ export function useLoginForm() {
       const { access_token, refresh_token, id_token } = await loginEmail(values);
 
       // 2. 쿠키 저장 + Zustand 상태 업데이트
-      login(access_token, refresh_token, id_token);
+      login(access_token, refresh_token, id_token, 'email');
 
       // 3. redirect 파라미터가 있으면 해당 경로로, 없으면 /my-space로 이동
       const redirect = searchParams.get('redirect') || '/my-space/case';

--- a/src/components/MySpaceSidebar.tsx
+++ b/src/components/MySpaceSidebar.tsx
@@ -27,6 +27,16 @@ import {
   SidebarSeparator,
   SidebarTrigger,
 } from '@/components/ui/sidebar';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuItem,
+  AppDropdownMenuContent,
+  AppDropdownMenuSeparator,
+} from '@/components/AppDropdownMenu';
+import EllipsisIcon from '@/assets/icons/ellipsis-vertical.svg';
+import { LogOut, User } from 'lucide-react';
+import { useLogout } from '@/hooks/useLogout';
 import SidebarIcon1 from '@/assets/icons/Sidebar-icon-1.svg';
 import SidebarIcon2 from '@/assets/icons/Sidebar-icon-2.svg';
 import SidebarIcon3 from '@/assets/icons/Sidebar-icon-3.svg';
@@ -58,6 +68,7 @@ export function MySpaceSidebar() {
   const pathname = usePathname();
   const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
   const user = useAuthStore((s) => s.user);
+  const { handleLogout } = useLogout();
 
   return (
     <Sidebar
@@ -152,7 +163,6 @@ export function MySpaceSidebar() {
 
         <SidebarSeparator className="mx-0 transition-opacity delay-150 duration-300 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-0" />
 
-        {/* TODO: 유저 메뉴 추후 연결 */}
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton
@@ -162,7 +172,7 @@ export function MySpaceSidebar() {
             >
               <div className="flex items-center gap-2 px-1 py-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:px-0">
                 <ProfileIcon className="size-5 shrink-0" />
-                <span className="typo-body-3 text-gray-600 transition-opacity delay-150 duration-300 group-data-[collapsible=icon]:w-0 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-0">
+                <span className="typo-body-3 flex-1 text-gray-600 transition-opacity delay-150 duration-300 group-data-[collapsible=icon]:w-0 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-0">
                   {isLoggedIn ? (
                     user?.name ? (
                       `${user.name}님`
@@ -173,6 +183,35 @@ export function MySpaceSidebar() {
                     'Guest'
                   )}
                 </span>
+                {isLoggedIn && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        className="shrink-0 p-1 text-gray-400 transition-opacity delay-150 duration-300 group-data-[collapsible=icon]:w-0 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:delay-0"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <EllipsisIcon width={16} height={16} />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <AppDropdownMenuContent side="top" align="end">
+                      <DropdownMenuItem
+                        disabled
+                        className="typo-body-6 cursor-not-allowed text-gray-400"
+                      >
+                        <User size={16} />
+                        마이페이지
+                      </DropdownMenuItem>
+                      <AppDropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={handleLogout}
+                        className="typo-body-6 text-error cursor-pointer hover:bg-gray-50 focus:bg-gray-50"
+                      >
+                        <LogOut size={16} />
+                        로그아웃
+                      </DropdownMenuItem>
+                    </AppDropdownMenuContent>
+                  </DropdownMenu>
+                )}
               </div>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/src/hooks/useGoogle.ts
+++ b/src/hooks/useGoogle.ts
@@ -3,8 +3,8 @@ import { useEffect, useState } from 'react';
 import { useAuthStore } from '@/stores/authStore';
 import { getGoogleToken } from '@/api/auth/google';
 
-const appUrl = process.env.NEXT_PUBLIC_APP_URL!.replace(/\/$/, '');
-const cognitoDomain = process.env.NEXT_PUBLIC_COGNITO_DOMAIN!.replace(/\/$/, '');
+const appUrl = (process.env.NEXT_PUBLIC_APP_URL ?? '').replace(/\/$/, '');
+const cognitoDomain = (process.env.NEXT_PUBLIC_COGNITO_DOMAIN ?? '').replace(/\/$/, '');
 
 export function useGoogleAuth() {
   const logout = useAuthStore((state) => state.logout);

--- a/src/hooks/useGoogle.ts
+++ b/src/hooks/useGoogle.ts
@@ -3,6 +3,9 @@ import { useEffect, useState } from 'react';
 import { useAuthStore } from '@/stores/authStore';
 import { getGoogleToken } from '@/api/auth/google';
 
+const appUrl = process.env.NEXT_PUBLIC_APP_URL!.replace(/\/$/, '');
+const cognitoDomain = process.env.NEXT_PUBLIC_COGNITO_DOMAIN!.replace(/\/$/, '');
+
 export function useGoogleAuth() {
   const logout = useAuthStore((state) => state.logout);
 
@@ -15,7 +18,7 @@ export function useGoogleAuth() {
       client_id: process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID!,
       response_type: 'code',
       scope: 'openid email profile aws.cognito.signin.user.admin',
-      redirect_uri: `${process.env.NEXT_PUBLIC_APP_URL}/auth/login`,
+      redirect_uri: `${appUrl}/auth/login`,
       identity_provider: 'Google',
     });
 
@@ -23,7 +26,7 @@ export function useGoogleAuth() {
       params.set('state', redirect);
     }
 
-    window.location.href = `${process.env.NEXT_PUBLIC_COGNITO_DOMAIN}/oauth2/authorize?${params.toString()}`;
+    window.location.href = `${cognitoDomain}/oauth2/authorize?${params.toString()}`;
   };
 
   // (2) 구글 로그아웃 함수
@@ -34,10 +37,10 @@ export function useGoogleAuth() {
     // 2. Cognito 세션 로그아웃
     const params = new URLSearchParams({
       client_id: process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID!,
-      logout_uri: `${process.env.NEXT_PUBLIC_APP_URL}/auth/login`,
+      logout_uri: `${appUrl}/auth/login`,
     });
 
-    window.location.href = `${process.env.NEXT_PUBLIC_COGNITO_DOMAIN}/logout?${params.toString()}`;
+    window.location.href = `${cognitoDomain}/logout?${params.toString()}`;
   };
 
   return { loginWithGoogle, logoutWithGoogle };
@@ -61,7 +64,7 @@ export function useGoogleLoginSideEffect() {
         const { access_token, refresh_token, id_token } = await getGoogleToken(code);
 
         // 2. 토큰 저장
-        login(access_token, refresh_token, id_token);
+        login(access_token, refresh_token, id_token, 'google');
         setGoogleLoading(false);
 
         // 3. OAuth state에서 redirect 경로 읽고 이동

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/stores/authStore';
+import { logoutApi } from '@/api/auth/login';
+import { useGoogleAuth } from '@/hooks/useGoogle';
+
+export function useLogout() {
+  const router = useRouter();
+  const loginMethod = useAuthStore((s) => s.loginMethod);
+  const logout = useAuthStore((s) => s.logout);
+  const { logoutWithGoogle } = useGoogleAuth();
+
+  const handleLogout = async () => {
+    if (loginMethod === 'email') {
+      await logoutApi();
+      logout();
+      router.push('/auth/login');
+    } else {
+      logoutWithGoogle();
+    }
+  };
+
+  return { handleLogout };
+}

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -18,8 +18,14 @@ interface AuthState {
   isAuthInitialized: boolean;
   user: User | null;
   sseBaseUrl: string | null;
+  loginMethod: 'google' | 'email' | null;
 
-  login: (accessToken: string, refreshToken: string, idToken: string) => void;
+  login: (
+    accessToken: string,
+    refreshToken: string,
+    idToken: string,
+    method: 'google' | 'email',
+  ) => void;
   logout: () => void;
   initAuth: () => void;
   fetchUser: () => Promise<void>;
@@ -31,15 +37,16 @@ export const useAuthStore = create<AuthState>((set) => ({
   isAuthInitialized: false,
   user: null,
   sseBaseUrl: null,
+  loginMethod: null,
 
-  login: (accessToken, refreshToken, idToken) => {
+  login: (accessToken, refreshToken, idToken, method) => {
     authCookies.setTokens(accessToken, refreshToken, idToken);
-    set({ isLoggedIn: true });
+    set({ isLoggedIn: true, loginMethod: method });
   },
 
   logout: () => {
     authCookies.clearTokens();
-    set({ isLoggedIn: false, user: null, sseBaseUrl: null });
+    set({ isLoggedIn: false, user: null, sseBaseUrl: null, loginMethod: null });
   },
 
   initAuth: () => {


### PR DESCRIPTION
## 작업 내용

**사이드바 유저 메뉴**
로그인한 유저에게만 사이드바 하단 유저 이름 옆에 점3개(⋮) 버튼을 표시합니다. 
클릭 시 팝오버 메뉴가 열리며 아래 항목이 포함됩니다.

- 마이페이지: 준비 예정으로 disabled 처리
- 로그아웃: 로그인 방식에 따라 분기 처리
- 비로그인 상태 및 사이드바 접힌 상태에서는 버튼이 표시되지 않음

**로그아웃 분기 처리**
기존에는 구글 로그아웃 함수만 존재했으나, 이메일 로그인 유저의 경우 서버 측 리프레시 토큰 무효화가 필요합니다. loginMethod를 기준으로 분기합니다.

- 구글: Cognito 세션 종료(/logout) 후 /auth/login 리다이렉트
- 이메일: POST /api/v1/users/logout 호출 후 /auth/login 이동

**주요 변경 사항**
- authStore에 loginMethod: 'google' | 'email' | null 상태 추가, login() 시그니처에 method 파라미터 추가
- useLogout 훅 신규 생성 — 로그아웃 분기 로직 통합
- fix: NEXT_PUBLIC_APP_URL, NEXT_PUBLIC_COGNITO_DOMAIN에 trailing slash가 있을 때 이중 슬래시 URL이 생성되던 버그 수정

##이슈 번호
close #63 

##스크린샷 (선택)
<img width="401" height="212" alt="image" src="https://github.com/user-attachments/assets/0ed9e9cb-2ac0-4f90-bba5-24e576506707" />
